### PR TITLE
Input Masks

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-helmet": "5.2.0",
     "react-html-parser": "2.0.2",
     "react-live": "1.12.0",
+    "react-text-mask": "5.4.3",
     "react-textarea-autosize": "7.1.0",
     "recursive-readdir-sync": "1.0.6",
     "rsvp": "4.8.4",

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import MaskedInput from 'react-text-mask';
 
 import { FormFooter, FormLabel, Icon } from '.';
 import { generateUUID } from '../helpers/utility';
@@ -65,7 +66,7 @@ class Input extends React.Component {
   }
 
   render() {
-    const { autoComplete, className, disabled, focus, label, name, type, placeholder, validationMessage, explanationMessage, prefixIcon, required } = this.props;
+    const { autoComplete, className, disabled, focus, label, guide, mask, name, type, placeholder, validationMessage, explanationMessage, prefixIcon, required } = this.props;
     const { value } = this.state;
 
     const classes = cx('form-group', className, {
@@ -73,22 +74,37 @@ class Input extends React.Component {
       [config.classes.required]: required,
     });
 
-    const inputRender = () => (
-      <input
-        autoComplete={autoComplete}
-        id={this.id}
-        className="form-input"
-        disabled={disabled}
-        focus={focus}
-        name={name}
-        type={type}
-        value={value}
-        onChange={this.handleChange}
-        onKeyPress={this.handleKeyPress}
-        placeholder={placeholder}
-        ref={(ref) => { this.input = ref; }}
-      />
-    );
+    const inputRender = () => {
+      const defaultProps = {
+        autoComplete,
+        id: this.id,
+        className: 'form-input',
+        disabled,
+        focus,
+        name,
+        type,
+        value,
+        onChange: this.handleChange,
+        onKeyPress: this.handleKeyPress,
+        placeholder,
+        ref: (ref) => { this.input = ref; },
+      };
+
+      // `react-text-mask` does not support 'email' or 'number' input types
+      if (mask && !['email', 'number'].includes(type)) {
+        return (
+          <MaskedInput
+            {... defaultProps}
+            mask={mask}
+            guide={guide}
+          />
+        );
+      }
+
+      return (
+        <input {... defaultProps} />
+      );
+    };
 
     return (
       <div className={classes}>
@@ -116,6 +132,7 @@ Input.propTypes = {
   validationMessage: PropTypes.string,
   disabled: PropTypes.bool,
   focus: PropTypes.bool,
+  guide: PropTypes.bool,
   initialValue: PropTypes.string,
   onChange: PropTypes.func,
   onKeyPress: PropTypes.func,
@@ -123,12 +140,14 @@ Input.propTypes = {
   prefixIcon: PropTypes.string,
   required: PropTypes.bool,
   label: PropTypes.string,
+  mask: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
   name: PropTypes.string.isRequired,
   type: PropTypes.string,
 };
 
 Input.defaultProps = {
   type: 'text',
+  guide: false,
 };
 
 export default Input;

--- a/src/pages/input.js
+++ b/src/pages/input.js
@@ -6,6 +6,17 @@ import { Input } from '../components';
 
 const phoneMask = ['+', '1', ' ', '(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/];
 
+const onlyNumbers = (rawValue) => {
+  const mask = [];
+
+  for (let i = 0; i < rawValue.length; i += 1) {
+    // eslint-disable-next-line no-useless-escape
+    mask.push(/\d/);
+  }
+
+  return mask;
+};
+
 const InputExample = `
 class Example extends React.Component {
   state = {
@@ -34,6 +45,13 @@ class Example extends React.Component {
           mask={phoneMask}
           onChange={this.handleChange}
         />
+        <Input
+          label="Mask Input (only numbers)"
+          name="phone"
+          placeholder="12345"
+          mask={onlyNumbers}
+          onChange={this.handleChange}
+        />
       </Fragment>
     );
   }
@@ -44,6 +62,7 @@ const InputScope = {
   React,
   Input,
   phoneMask,
+  onlyNumbers,
 };
 
 const InputPropDescriptions = {

--- a/src/pages/input.js
+++ b/src/pages/input.js
@@ -4,18 +4,37 @@ import FoundationLayout from '../layouts/Foundation';
 import Live from '../docs/Live';
 import { Input } from '../components';
 
+const phoneMask = ['+', '1', ' ', '(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/];
+
 const InputExample = `
 class Example extends React.Component {
   state = {
-    initialValue: 'I have an initial value!',
+    normalInitialValue: 'John Doe',
   };
+
+  handleChange = (name, value) => {
+    console.log({name}, {value});
+  }
 
   render() {
     return (
-      <Input
-        label="Test label"
-        name="test" initialValue={this.state.initialValue}
-      />
+      <Fragment>
+        <Input
+          label="Normal input"
+          name="name"
+          initialValue={this.state.normalInitialValue}
+          onChange={this.handleChange}
+          required
+          validationMessage="I'm an error!"
+        />
+        <Input
+          label="Mask Input (phone number)"
+          name="phone"
+          placeholder="+1 (555) 867-5309"
+          mask={phoneMask}
+          onChange={this.handleChange}
+        />
+      </Fragment>
     );
   }
 }
@@ -24,15 +43,20 @@ class Example extends React.Component {
 const InputScope = {
   React,
   Input,
+  phoneMask,
 };
 
 const InputPropDescriptions = {
   explanationMessage: 'Field descriptions',
   validationMessage: 'Error messages with field',
+  guide: 'Show guide while typing; used in conjunction with <code>mask</code>',
+  mask: 'Mask to apply to input; by <a target="_blank" rel="noopener noreferrer" href="https://github.com/text-mask/text-mask/">text-mask</a>',
 };
 
 const InputDocs = () => (
   <FoundationLayout pageTitle="Input">
+    <p>Uses <a target="_blank" rel="noopener noreferrer" href="https://github.com/text-mask/text-mask/">text-mask</a> to provide masking capabilities for better UX.</p>
+
     <Live
       code={InputExample}
       scope={InputScope}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9334,7 +9334,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
@@ -9624,6 +9624,13 @@ react-side-effect@^1.1.0:
   dependencies:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
+
+react-text-mask@5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/react-text-mask/-/react-text-mask-5.4.3.tgz#991efb4299e30c2e6c2c46d13f617169463e0d2d"
+  integrity sha1-mR77QpnjDC5sLEbRP2FxaUY+DS0=
+  dependencies:
+    prop-types "^15.5.6"
 
 react-textarea-autosize@7.1.0:
   version "7.1.0"


### PR DESCRIPTION
Uses the [text-mask](https://github.com/text-mask/text-mask) library to provide input mask functionality. This is needed for support app integration so we auto-format certain types of fields.