### PR TITLE
Placeholders

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -51,7 +51,7 @@ module.exports = {
       resolve: 'gatsby-mdx',
       options: {
         defaultLayouts: {
-          default: require.resolve('./src/layouts/Article.js'),
+          default: require.resolve('./src/templates/Article.js'),
         },
         gatsbyRemarkPlugins: [
           {

--- a/src/assets/styles/_alert.scss
+++ b/src/assets/styles/_alert.scss
@@ -24,7 +24,7 @@ $alert-danger-color: $global-danger !default;
 //
 
 @mixin alert() {
-  @include selector-placeholder(alert) {
+  @include selector-placeholder('.alert') {
     display: flex;
     background: $alert-default-color;
     border-left: $alert-border-width solid $alert-default-border;
@@ -32,11 +32,6 @@ $alert-danger-color: $global-danger !default;
 
     @media (min-width: $global-viewport-medium) {
       padding: $global-whitespace-medium;
-    }
-
-    // For `gatsby-remark-custom-blocks` integration
-    .custom-block-heading {
-      @extend %h4;
     }
 
     // Reset emphasis and link colors
@@ -48,7 +43,7 @@ $alert-danger-color: $global-danger !default;
 
     a:not([class]),
     .u-link {
-      @extend .u-textUnderline;
+      @extend %u-textUnderline;
     }
 
     // Add margin if adjacent element
@@ -60,7 +55,7 @@ $alert-danger-color: $global-danger !default;
   }
 
   @if $alert-primary-enable {
-    @include selector-placeholder(alert--primary) {
+    @include selector-placeholder('.alert--primary') {
       background: $alert-primary-background;
       border-color: $alert-primary-color;
 
@@ -69,7 +64,7 @@ $alert-danger-color: $global-danger !default;
   }
 
   @if $alert-warning-enable {
-    @include selector-placeholder(alert--warning) {
+    @include selector-placeholder('.alert--warning') {
       background: $alert-warning-background;
       border-color: $alert-warning-color;
 
@@ -78,12 +73,11 @@ $alert-danger-color: $global-danger !default;
   }
 
   @if $alert-danger-enable {
-    @include selector-placeholder(alert--danger) {
+    @include selector-placeholder('.alert--danger') {
       background: $alert-danger-background;
       border-color: $alert-danger-color;
 
       .alert-title,
-      .custom-block-heading,
       .alert-close {
         color: $alert-danger-color;
       }
@@ -92,13 +86,13 @@ $alert-danger-color: $global-danger !default;
     }
   }
 
-  @include selector-placeholder(alert-content) {
+  @include selector-placeholder('.alert-content') {
     @include trimChildren();
 
     flex: 1;
   }
 
-  @include selector-placeholder(alert-right) {
+  @include selector-placeholder('.alert-right') {
     flex: 0;
     padding-left: $global-whitespace-small;
   }

--- a/src/assets/styles/_alert.scss
+++ b/src/assets/styles/_alert.scss
@@ -96,4 +96,6 @@ $alert-danger-color: $global-danger !default;
     flex: 0;
     padding-left: $global-whitespace-small;
   }
+
+  @if (mixin-exists(hook-alert-misc)) { @include hook-alert-misc(); }
 }

--- a/src/assets/styles/_alert.scss
+++ b/src/assets/styles/_alert.scss
@@ -24,7 +24,7 @@ $alert-danger-color: $global-danger !default;
 //
 
 @mixin alert() {
-  @include selector-placeholder('.alert') {
+  @include selector-placeholder('alert') {
     display: flex;
     background: $alert-default-color;
     border-left: $alert-border-width solid $alert-default-border;
@@ -55,7 +55,7 @@ $alert-danger-color: $global-danger !default;
   }
 
   @if $alert-primary-enable {
-    @include selector-placeholder('.alert--primary') {
+    @include selector-placeholder('alert--primary') {
       background: $alert-primary-background;
       border-color: $alert-primary-color;
 
@@ -64,7 +64,7 @@ $alert-danger-color: $global-danger !default;
   }
 
   @if $alert-warning-enable {
-    @include selector-placeholder('.alert--warning') {
+    @include selector-placeholder('alert--warning') {
       background: $alert-warning-background;
       border-color: $alert-warning-color;
 
@@ -73,7 +73,7 @@ $alert-danger-color: $global-danger !default;
   }
 
   @if $alert-danger-enable {
-    @include selector-placeholder('.alert--danger') {
+    @include selector-placeholder('alert--danger') {
       background: $alert-danger-background;
       border-color: $alert-danger-color;
 
@@ -86,13 +86,13 @@ $alert-danger-color: $global-danger !default;
     }
   }
 
-  @include selector-placeholder('.alert-content') {
+  @include selector-placeholder('alert-content') {
     @include trimChildren();
 
     flex: 1;
   }
 
-  @include selector-placeholder('.alert-right') {
+  @include selector-placeholder('alert-right') {
     flex: 0;
     padding-left: $global-whitespace-small;
   }

--- a/src/assets/styles/_alert.scss
+++ b/src/assets/styles/_alert.scss
@@ -24,7 +24,7 @@ $alert-danger-color: $global-danger !default;
 //
 
 @mixin alert() {
-  .alert {
+  @include selector-placeholder(alert) {
     display: flex;
     background: $alert-default-color;
     border-left: $alert-border-width solid $alert-default-border;
@@ -36,7 +36,7 @@ $alert-danger-color: $global-danger !default;
 
     // For `gatsby-remark-custom-blocks` integration
     .custom-block-heading {
-      @extend h4;
+      @extend %h4;
     }
 
     // Reset emphasis and link colors
@@ -51,55 +51,55 @@ $alert-danger-color: $global-danger !default;
       @extend .u-textUnderline;
     }
 
-    @if $alert-primary-enable {
-      &--primary {
-        background: $alert-primary-background;
-        border-color: $alert-primary-color;
-
-        @if (mixin-exists(hook-alert-primary)) { @include hook-alert-primary(); }
-      }
-    }
-
-    @if $alert-warning-enable {
-      &--warning {
-        background: $alert-warning-background;
-        border-color: $alert-warning-color;
-
-        @if (mixin-exists(hook-alert-warning)) { @include hook-alert-warning(); }
-      }
-    }
-
-    @if $alert-danger-enable {
-      &--danger {
-        background: $alert-danger-background;
-        border-color: $alert-danger-color;
-
-        .alert-title,
-        .custom-block-heading,
-        .alert-close {
-          color: $alert-danger-color;
-        }
-
-        @if (mixin-exists(hook-alert-danger)) { @include hook-alert-danger(); }
-      }
-    }
-
-    &-content {
-      @include trimChildren();
-
-      flex: 1;
-    }
-
-    &-right {
-      flex: 0;
-      padding-left: $global-whitespace-small;
+    // Add margin if adjacent element
+    * + .alert {
+      margin-top: $global-whitespace-regular;
     }
 
     @if (mixin-exists(hook-alert)) { @include hook-alert(); }
   }
 
-  // Add margin if adjacent element
-  * + .alert {
-    margin-top: $global-whitespace-regular;
+  @if $alert-primary-enable {
+    @include selector-placeholder(alert--primary) {
+      background: $alert-primary-background;
+      border-color: $alert-primary-color;
+
+      @if (mixin-exists(hook-alert-primary)) { @include hook-alert-primary(); }
+    }
+  }
+
+  @if $alert-warning-enable {
+    @include selector-placeholder(alert--warning) {
+      background: $alert-warning-background;
+      border-color: $alert-warning-color;
+
+      @if (mixin-exists(hook-alert-warning)) { @include hook-alert-warning(); }
+    }
+  }
+
+  @if $alert-danger-enable {
+    @include selector-placeholder(alert--danger) {
+      background: $alert-danger-background;
+      border-color: $alert-danger-color;
+
+      .alert-title,
+      .custom-block-heading,
+      .alert-close {
+        color: $alert-danger-color;
+      }
+
+      @if (mixin-exists(hook-alert-danger)) { @include hook-alert-danger(); }
+    }
+  }
+
+  @include selector-placeholder(alert-content) {
+    @include trimChildren();
+
+    flex: 1;
+  }
+
+  @include selector-placeholder(alert-right) {
+    flex: 0;
+    padding-left: $global-whitespace-small;
   }
 }

--- a/src/assets/styles/_avatar.scss
+++ b/src/assets/styles/_avatar.scss
@@ -14,8 +14,7 @@ $avatar-font-color: $global-font-color;
 
 @mixin avatar() {
   // 1. Fix issue with alignment of inlined avatars
-  .avatar,
-  %avatar {
+  .avatar {
     background-color: $avatar-background;
     background-position: center center;
     background-size: cover;
@@ -56,8 +55,7 @@ $avatar-font-color: $global-font-color;
     }
   }
 
-  .avatar--large,
-  %avatar--large {
+  .avatar--large {
     size: $avatar-size-large;
   }
 }

--- a/src/assets/styles/_avatar.scss
+++ b/src/assets/styles/_avatar.scss
@@ -14,7 +14,8 @@ $avatar-font-color: $global-font-color;
 
 @mixin avatar() {
   // 1. Fix issue with alignment of inlined avatars
-  .avatar {
+  .avatar,
+  %avatar {
     background-color: $avatar-background;
     background-position: center center;
     background-size: cover;
@@ -55,7 +56,8 @@ $avatar-font-color: $global-font-color;
     }
   }
 
-  .avatar--large {
+  .avatar--large,
+  %avatar--large {
     size: $avatar-size-large;
   }
 }

--- a/src/assets/styles/_avatar.scss
+++ b/src/assets/styles/_avatar.scss
@@ -28,6 +28,8 @@ $avatar-font-color: $global-font-color;
     vertical-align: bottom; // 1
     size: $avatar-size;
 
+    @if (mixin-exists(hook-avatar)) { @include hook-avatar(); }
+
     // Placed inside of `.avatar` to override default `icon` styles
     .avatar-icon {
       position: absolute;
@@ -58,4 +60,6 @@ $avatar-font-color: $global-font-color;
   .avatar--large {
     size: $avatar-size-large;
   }
+
+  @if (mixin-exists(hook-avatar-misc)) { @include hook-avatar-misc(); }
 }

--- a/src/assets/styles/_badge.scss
+++ b/src/assets/styles/_badge.scss
@@ -15,7 +15,8 @@ $badge-rounded-enable: true !default;
 //
 
 @mixin badge() {
-  .badge {
+  .badge,
+  %badge {
     background: $global-background;
     border: 1px solid $global-border;
     border-radius: $global-border-radius;
@@ -33,28 +34,31 @@ $badge-rounded-enable: true !default;
     text-transform: uppercase;
     user-select: none;
 
-    @if $badge-primary-enable {
-      &--primary {
-        border-color: $global-primary;
-        background: $global-primary;
-        color: $global-contrast;
-      }
-    }
-
-    @if $badge-danger-enable {
-      &--danger {
-        border-color: $global-danger;
-        background: $global-danger;
-        color: $global-contrast;
-      }
-    }
-
-    @if $badge-rounded-enable {
-      &--rounded {
-        border-radius: ($badge-height / 2);
-      }
-    }
-
     @if (mixin-exists(hook-badge)) { @include hook-badge(); }
+  }
+
+  @if $badge-primary-enable {
+    .badge--primary,
+    %badge--primary {
+      border-color: $global-primary;
+      background: $global-primary;
+      color: $global-contrast;
+    }
+  }
+
+  @if $badge-danger-enable {
+    .badge--danger,
+    %badge--danger {
+      border-color: $global-danger;
+      background: $global-danger;
+      color: $global-contrast;
+    }
+  }
+
+  @if $badge-rounded-enable {
+    .badge--rounded,
+    %badge--rounded {
+      border-radius: ($badge-height / 2);
+    }
   }
 }

--- a/src/assets/styles/_badge.scss
+++ b/src/assets/styles/_badge.scss
@@ -15,8 +15,7 @@ $badge-rounded-enable: true !default;
 //
 
 @mixin badge() {
-  .badge,
-  %badge {
+  .badge {
     background: $global-background;
     border: 1px solid $global-border;
     border-radius: $global-border-radius;
@@ -38,8 +37,7 @@ $badge-rounded-enable: true !default;
   }
 
   @if $badge-primary-enable {
-    .badge--primary,
-    %badge--primary {
+    .badge--primary {
       border-color: $global-primary;
       background: $global-primary;
       color: $global-contrast;
@@ -47,8 +45,7 @@ $badge-rounded-enable: true !default;
   }
 
   @if $badge-danger-enable {
-    .badge--danger,
-    %badge--danger {
+    .badge--danger {
       border-color: $global-danger;
       background: $global-danger;
       color: $global-contrast;
@@ -56,8 +53,7 @@ $badge-rounded-enable: true !default;
   }
 
   @if $badge-rounded-enable {
-    .badge--rounded,
-    %badge--rounded {
+    .badge--rounded {
       border-radius: ($badge-height / 2);
     }
   }

--- a/src/assets/styles/_badge.scss
+++ b/src/assets/styles/_badge.scss
@@ -57,4 +57,6 @@ $badge-rounded-enable: true !default;
       border-radius: ($badge-height / 2);
     }
   }
+
+  @if (mixin-exists(hook-badge-misc)) { @include hook-badge-misc(); }
 }

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -361,7 +361,7 @@ $base-selection-color: $global-background !default;
   //
 
   // Sizes
-  @include selector-placeholder(h1) {
+  @include selector-placeholder('h1') {
     @include base-heading-styles();
 
     @extend %u-textFluid--h1-h2;
@@ -372,7 +372,7 @@ $base-selection-color: $global-background !default;
     @if (mixin-exists(hook-base-h1)) { @include hook-base-h1(); }
   }
 
-  @include selector-placeholder(h2) {
+  @include selector-placeholder('h2') {
     @include base-heading-styles();
 
     @extend %u-textFluid--h2-h3;
@@ -383,7 +383,7 @@ $base-selection-color: $global-background !default;
     @if (mixin-exists(hook-base-h2)) { @include hook-base-h2(); }
   }
 
-  @include selector-placeholder(h3) {
+  @include selector-placeholder('h3') {
     @include base-heading-styles();
 
     @extend %u-textFluid--h3-h4;
@@ -394,7 +394,7 @@ $base-selection-color: $global-background !default;
     @if (mixin-exists(hook-base-h3)) { @include hook-base-h3(); }
   }
 
-  @include selector-placeholder(h4) {
+  @include selector-placeholder('h4') {
     @include base-heading-styles();
 
     font-size: $base-h4-font-size;
@@ -404,7 +404,7 @@ $base-selection-color: $global-background !default;
     @if (mixin-exists(hook-base-h4)) { @include hook-base-h4(); }
   }
 
-  @include selector-placeholder(h5) {
+  @include selector-placeholder('h5') {
     @include base-heading-styles();
 
     font-size: $base-h5-font-size;

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -70,6 +70,22 @@ $base-selection-background: $global-primary !default;
 $base-selection-color: $global-background !default;
 
 //
+// Mixins
+//
+
+@mixin base-heading-styles() {
+  margin: 0 0 $base-margin-vertical;
+  font-family: $base-heading-font-family;
+  color: $base-heading-color;
+  text-transform: $base-heading-text-transform;
+  letter-spacing: $base-heading-letter-spacing;
+
+  * + & {
+    margin-top: $base-heading-margin-top;
+  }
+}
+
+//
 // Component
 //
 
@@ -344,32 +360,11 @@ $base-selection-color: $global-background !default;
   // Headings
   //
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5 {
-    margin: 0 0 $base-margin-vertical;
-    font-family: $base-heading-font-family;
-    color: $base-heading-color;
-    text-transform: $base-heading-text-transform;
-    letter-spacing: $base-heading-letter-spacing;
-
-    @if (mixin-exists(hook-base-h)) { @include hook-base-h(); }
-  }
-
-  // Margins
-  * + h1,
-  * + h2,
-  * + h3,
-  * + h4,
-  * + h5 {
-    margin-top: $base-heading-margin-top;
-  }
-
   // Sizes
-  h1 {
-    @extend .u-textFluid--h1-h2;
+  @include selector-placeholder(h1) {
+    @include base-heading-styles();
+
+    @extend %u-textFluid--h1-h2;
 
     font-weight: $base-h1-font-weight;
     line-height: $base-h1-line-height;
@@ -377,8 +372,10 @@ $base-selection-color: $global-background !default;
     @if (mixin-exists(hook-base-h1)) { @include hook-base-h1(); }
   }
 
-  h2 {
-    @extend .u-textFluid--h2-h3;
+  @include selector-placeholder(h2) {
+    @include base-heading-styles();
+
+    @extend %u-textFluid--h2-h3;
 
     font-weight: $base-h2-font-weight;
     line-height: $base-h2-line-height;
@@ -386,8 +383,10 @@ $base-selection-color: $global-background !default;
     @if (mixin-exists(hook-base-h2)) { @include hook-base-h2(); }
   }
 
-  h3 {
-    @extend .u-textFluid--h3-h4;
+  @include selector-placeholder(h3) {
+    @include base-heading-styles();
+
+    @extend %u-textFluid--h3-h4;
 
     font-weight: $base-h3-font-weight;
     line-height: $base-h3-line-height;
@@ -395,7 +394,9 @@ $base-selection-color: $global-background !default;
     @if (mixin-exists(hook-base-h3)) { @include hook-base-h3(); }
   }
 
-  h4 {
+  @include selector-placeholder(h4) {
+    @include base-heading-styles();
+
     font-size: $base-h4-font-size;
     font-weight: $base-h4-font-weight;
     line-height: $base-h4-line-height;
@@ -403,7 +404,9 @@ $base-selection-color: $global-background !default;
     @if (mixin-exists(hook-base-h4)) { @include hook-base-h4(); }
   }
 
-  h5 {
+  @include selector-placeholder(h5) {
+    @include base-heading-styles();
+
     font-size: $base-h5-font-size;
     font-weight: $base-h5-font-weight;
     line-height: $base-h5-line-height;

--- a/src/assets/styles/_button.scss
+++ b/src/assets/styles/_button.scss
@@ -382,4 +382,6 @@ $button-icon-enable: true !default;
       }
     }
   }
+
+  @if (mixin-exists(hook-button-misc)) { @include hook-button-misc(); }
 }

--- a/src/assets/styles/_button.scss
+++ b/src/assets/styles/_button.scss
@@ -83,7 +83,7 @@ $button-icon-enable: true !default;
   // 12. Do not wrap buttons
   // 13. Disable `user-select`
   // 14. Removes inner padding and border in Firefox 4+.
-  @include selector-placeholder('.button') {
+  @include selector-placeholder('button') {
     // 1
     appearance: none;
     // 2
@@ -188,7 +188,7 @@ $button-icon-enable: true !default;
   }
 
   @if $button-small-enable {
-    @include selector-placeholder('.button--small') {
+    @include selector-placeholder('button--small') {
       padding: 0 $global-whitespace-regular;
       font-size: $button-font-size-small;
       line-height: ($global-height-small - ($button-border-width * 2));
@@ -199,7 +199,7 @@ $button-icon-enable: true !default;
   }
 
   @if $button-xsmall-enable {
-    @include selector-placeholder('.button--xsmall') {
+    @include selector-placeholder('button--xsmall') {
       padding: 0 $global-whitespace-regular;
       font-size: $button-font-size-xsmall;
       line-height: ($global-height-xsmall - ($button-border-width * 2));
@@ -210,7 +210,7 @@ $button-icon-enable: true !default;
   }
 
   @if $button-default-enable {
-    @include selector-placeholder('.button--default') {
+    @include selector-placeholder('button--default') {
       background: $button-default-background;
       border-color: $button-default-border;
       color: $button-default-color;
@@ -244,7 +244,7 @@ $button-icon-enable: true !default;
   }
 
   @if $button-outline-primary-enable {
-    @include selector-placeholder('.button--outlinePrimary') {
+    @include selector-placeholder('button--outlinePrimary') {
       background: $button-outline-primary-background;
       border-color: $button-outline-primary-border;
       color: $button-outline-primary-color;
@@ -264,7 +264,7 @@ $button-icon-enable: true !default;
   }
 
   @if $button-primary-enable {
-    @include selector-placeholder('.button--primary') {
+    @include selector-placeholder('button--primary') {
       background: $button-primary-background;
       border-color: $button-primary-border;
       color: $button-primary-color;
@@ -298,7 +298,7 @@ $button-icon-enable: true !default;
   }
 
   @if $button-secondary-enable {
-    @include selector-placeholder('.button--secondary') {
+    @include selector-placeholder('button--secondary') {
       background: $button-secondary-background;
       border-color: $button-secondary-border;
       color: $button-secondary-color;
@@ -332,7 +332,7 @@ $button-icon-enable: true !default;
   }
 
   @if $button-danger-enable {
-    @include selector-placeholder('.button--danger') {
+    @include selector-placeholder('button--danger') {
       background: $button-danger-background;
       border-color: $button-danger-border;
       color: $global-contrast;
@@ -348,12 +348,12 @@ $button-icon-enable: true !default;
     }
   }
 
-  @include selector-placeholder('.button--fullWidth') {
+  @include selector-placeholder('button--fullWidth') {
     width: 100%;
   }
 
   @if $button-icon-enable {
-    @include selector-placeholder('.button--icon') {
+    @include selector-placeholder('button--icon') {
       padding: 0;
       width: $global-height;
 

--- a/src/assets/styles/_button.scss
+++ b/src/assets/styles/_button.scss
@@ -153,6 +153,38 @@ $button-icon-enable: true !default;
       }
     }
 
+    @if $button-loader-enable {
+      > .loader {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        opacity: 0;
+        size: $button-loader-size;
+
+        svg {
+          size: $button-loader-size;
+        }
+      }
+
+      &.is-loading {
+        span:not(.loader) {
+          color: transparent;
+        }
+
+        > .loader {
+          opacity: 1;
+        }
+      }
+    }
+
+    &.is-disabled,
+    &[disabled] {
+      opacity: $global-disabled-opacity;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
+
     @if (mixin-exists(hook-button)) { @include hook-button(); }
   }
 
@@ -350,37 +382,5 @@ $button-icon-enable: true !default;
         }
       }
     }
-  }
-
-  @if $button-loader-enable {
-    > .loader {
-      position: absolute;
-      left: 50%;
-      top: 50%;
-      transform: translate(-50%, -50%);
-      opacity: 0;
-      size: $button-loader-size;
-
-      svg {
-        size: $button-loader-size;
-      }
-    }
-
-    &.is-loading {
-      span:not(.loader) {
-        color: transparent;
-      }
-
-      > .loader {
-        opacity: 1;
-      }
-    }
-  }
-
-  &.is-disabled,
-  &[disabled] {
-    opacity: $global-disabled-opacity;
-    cursor: not-allowed;
-    pointer-events: none;
   }
 }

--- a/src/assets/styles/_button.scss
+++ b/src/assets/styles/_button.scss
@@ -83,8 +83,8 @@ $button-icon-enable: true !default;
   // 12. Do not wrap buttons
   // 13. Disable `user-select`
   // 14. Removes inner padding and border in Firefox 4+.
-  //
-  .button {
+
+  @include selector-placeholder('.button') {
     // 1
     appearance: none;
     // 2
@@ -153,234 +153,234 @@ $button-icon-enable: true !default;
       }
     }
 
-    @if $button-small-enable {
-      &--small {
-        padding: 0 $global-whitespace-regular;
-        font-size: $button-font-size-small;
-        line-height: ($global-height-small - ($button-border-width * 2));
-        height: $global-height-small;
-
-        @if (mixin-exists(hook-button-small)) { @include hook-button-small(); }
-      }
-    }
-
-    @if $button-xsmall-enable {
-      &--xsmall {
-        padding: 0 $global-whitespace-regular;
-        font-size: $button-font-size-xsmall;
-        line-height: ($global-height-xsmall - ($button-border-width * 2));
-        height: $global-height-xsmall;
-
-        @if (mixin-exists(hook-button-xsmall)) { @include hook-button-small(); }
-      }
-    }
-
-    @if $button-default-enable {
-      &--default {
-        background: $button-default-background;
-        border-color: $button-default-border;
-        color: $button-default-color;
-
-        &:hover,
-        &:focus,
-        &:active,
-        &.is-active {
-          color: $button-default-color;
-        }
-
-        @if $global-contrast-enable and $button-contrast-enable {
-          .u-contrast & {
-            &:not(.button--noContrast) {
-              background: $button-contrast-background;
-              color: $button-contrast-color;
-              border-color: currentColor;
-
-              &:hover,
-              &:focus,
-              &:active,
-              &.is-active {
-                color: $button-contrast-color;
-              }
-            }
-          }
-        }
-
-        @if (mixin-exists(hook-button-default)) { @include hook-button-default(); }
-      }
-    }
-
-    @if $button-outline-primary-enable {
-      &--outlinePrimary {
-        background: $button-outline-primary-background;
-        border-color: $button-outline-primary-border;
-        color: $button-outline-primary-color;
-        position: relative;
-        z-index: 2;
-
-        &:hover,
-        &:focus,
-        &:active,
-        &.is-active {
-          background: $button-outline-primary-background-hover;
-          color: $button-outline-primary-color-hover;
-        }
-
-        @if (mixin-exists(hook-button-outline-primary)) { @include hook-button-outline-primary(); }
-      }
-    }
-
-    @if $button-primary-enable {
-      &--primary {
-        background: $button-primary-background;
-        border-color: $button-primary-border;
-        color: $button-primary-color;
-
-        &:hover,
-        &:focus,
-        &:active,
-        &.is-active {
-          color: $button-primary-color;
-        }
-
-        @if $global-contrast-enable and $button-contrast-enable {
-          .u-contrast & {
-            &:not(.button--noContrast) {
-              background: $button-contrast-primary-background;
-              border-color: $button-contrast-primary-background;
-              color: $button-contrast-primary-color;
-
-              &:hover,
-              &:focus,
-              &:active,
-              &.is-active {
-                color: $button-contrast-primary-color;
-              }
-            }
-          }
-        }
-
-        @if (mixin-exists(hook-button-primary)) { @include hook-button-primary(); }
-      }
-    }
-
-    @if $button-secondary-enable {
-      &--secondary {
-        background: $button-secondary-background;
-        border-color: $button-secondary-border;
-        color: $button-secondary-color;
-
-        &:hover,
-        &:focus,
-        &:active,
-        &.is-active {
-          color: $button-secondary-color;
-        }
-
-        @if $global-contrast-enable and $button-contrast-enable {
-          .u-contrast & {
-            &:not(.button--noContrast) {
-              background: $button-contrast-secondary-background;
-              border-color: $button-contrast-secondary-background;
-              color: $button-contrast-secondary-color;
-
-              &:hover,
-              &:focus,
-              &:active,
-              &.is-active {
-                color: $button-contrast-secondary-color;
-              }
-            }
-          }
-        }
-
-        @if (mixin-exists(hook-button-secondary)) { @include hook-button-secondary(); }
-      }
-    }
-
-    @if $button-danger-enable {
-      &--danger {
-        background: $button-danger-background;
-        border-color: $button-danger-border;
-        color: $global-contrast;
-
-        &:hover,
-        &:focus,
-        &:active,
-        &.is-active {
-          color: $global-contrast;
-        }
-
-        @if (mixin-exists(hook-button-danger)) { @include hook-button-danger(); }
-      }
-    }
-
-    &--fullWidth {
-      width: 100%;
-    }
-
-    @if $button-icon-enable {
-      &--icon {
-        padding: 0;
-        width: $global-height;
-
-        svg {
-          size: $icon-size-large;
-        }
-
-        @if $button-small-enable {
-          &.button--small {
-            width: $global-height-small;
-
-            svg {
-              size: $icon-size-large;
-            }
-          }
-        }
-
-        @if $button-xsmall-enable {
-          &.button--xsmall {
-            width: $global-height-xsmall;
-
-            svg {
-              size: $icon-size;
-            }
-          }
-        }
-      }
-    }
-
-    @if $button-loader-enable {
-      > .loader {
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
-        opacity: 0;
-        size: $button-loader-size;
-
-        svg {
-          size: $button-loader-size;
-        }
-      }
-
-      &.is-loading {
-        span:not(.loader) {
-          color: transparent;
-        }
-
-        > .loader {
-          opacity: 1;
-        }
-      }
-    }
-
-    &.is-disabled,
-    &[disabled] {
-      opacity: $global-disabled-opacity;
-      cursor: not-allowed;
-      pointer-events: none;
-    }
-
     @if (mixin-exists(hook-button)) { @include hook-button(); }
+  }
+
+  @if $button-small-enable {
+    @include selector-placeholder('.button--small') {
+      padding: 0 $global-whitespace-regular;
+      font-size: $button-font-size-small;
+      line-height: ($global-height-small - ($button-border-width * 2));
+      height: $global-height-small;
+
+      @if (mixin-exists(hook-button-small)) { @include hook-button-small(); }
+    }
+  }
+
+  @if $button-xsmall-enable {
+    @include selector-placeholder('.button--xsmall') {
+      padding: 0 $global-whitespace-regular;
+      font-size: $button-font-size-xsmall;
+      line-height: ($global-height-xsmall - ($button-border-width * 2));
+      height: $global-height-xsmall;
+
+      @if (mixin-exists(hook-button-xsmall)) { @include hook-button-small(); }
+    }
+  }
+
+  @if $button-default-enable {
+    @include selector-placeholder('.button--default') {
+      background: $button-default-background;
+      border-color: $button-default-border;
+      color: $button-default-color;
+
+      &:hover,
+      &:focus,
+      &:active,
+      &.is-active {
+        color: $button-default-color;
+      }
+
+      @if $global-contrast-enable and $button-contrast-enable {
+        .u-contrast & {
+          &:not(.button--noContrast) {
+            background: $button-contrast-background;
+            color: $button-contrast-color;
+            border-color: currentColor;
+
+            &:hover,
+            &:focus,
+            &:active,
+            &.is-active {
+              color: $button-contrast-color;
+            }
+          }
+        }
+      }
+
+      @if (mixin-exists(hook-button-default)) { @include hook-button-default(); }
+    }
+  }
+
+  @if $button-outline-primary-enable {
+    @include selector-placeholder('.button--outlinePrimary') {
+      background: $button-outline-primary-background;
+      border-color: $button-outline-primary-border;
+      color: $button-outline-primary-color;
+      position: relative;
+      z-index: 2;
+
+      &:hover,
+      &:focus,
+      &:active,
+      &.is-active {
+        background: $button-outline-primary-background-hover;
+        color: $button-outline-primary-color-hover;
+      }
+
+      @if (mixin-exists(hook-button-outline-primary)) { @include hook-button-outline-primary(); }
+    }
+  }
+
+  @if $button-primary-enable {
+    @include selector-placeholder('.button--primary') {
+      background: $button-primary-background;
+      border-color: $button-primary-border;
+      color: $button-primary-color;
+
+      &:hover,
+      &:focus,
+      &:active,
+      &.is-active {
+        color: $button-primary-color;
+      }
+
+      @if $global-contrast-enable and $button-contrast-enable {
+        .u-contrast & {
+          &:not(.button--noContrast) {
+            background: $button-contrast-primary-background;
+            border-color: $button-contrast-primary-background;
+            color: $button-contrast-primary-color;
+
+            &:hover,
+            &:focus,
+            &:active,
+            &.is-active {
+              color: $button-contrast-primary-color;
+            }
+          }
+        }
+      }
+
+      @if (mixin-exists(hook-button-primary)) { @include hook-button-primary(); }
+    }
+  }
+
+  @if $button-secondary-enable {
+    @include selector-placeholder('.button--secondary') {
+      background: $button-secondary-background;
+      border-color: $button-secondary-border;
+      color: $button-secondary-color;
+
+      &:hover,
+      &:focus,
+      &:active,
+      &.is-active {
+        color: $button-secondary-color;
+      }
+
+      @if $global-contrast-enable and $button-contrast-enable {
+        .u-contrast & {
+          &:not(.button--noContrast) {
+            background: $button-contrast-secondary-background;
+            border-color: $button-contrast-secondary-background;
+            color: $button-contrast-secondary-color;
+
+            &:hover,
+            &:focus,
+            &:active,
+            &.is-active {
+              color: $button-contrast-secondary-color;
+            }
+          }
+        }
+      }
+
+      @if (mixin-exists(hook-button-secondary)) { @include hook-button-secondary(); }
+    }
+  }
+
+  @if $button-danger-enable {
+    @include selector-placeholder('.button--danger') {
+      background: $button-danger-background;
+      border-color: $button-danger-border;
+      color: $global-contrast;
+
+      &:hover,
+      &:focus,
+      &:active,
+      &.is-active {
+        color: $global-contrast;
+      }
+
+      @if (mixin-exists(hook-button-danger)) { @include hook-button-danger(); }
+    }
+  }
+
+  @include selector-placeholder('.button--fullWidth') {
+    width: 100%;
+  }
+
+  @if $button-icon-enable {
+    @include selector-placeholder('.button--icon') {
+      padding: 0;
+      width: $global-height;
+
+      svg {
+        size: $icon-size-large;
+      }
+
+      @if $button-small-enable {
+        &.button--small {
+          width: $global-height-small;
+
+          svg {
+            size: $icon-size-large;
+          }
+        }
+      }
+
+      @if $button-xsmall-enable {
+        &.button--xsmall {
+          width: $global-height-xsmall;
+
+          svg {
+            size: $icon-size;
+          }
+        }
+      }
+    }
+  }
+
+  @if $button-loader-enable {
+    > .loader {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      opacity: 0;
+      size: $button-loader-size;
+
+      svg {
+        size: $button-loader-size;
+      }
+    }
+
+    &.is-loading {
+      span:not(.loader) {
+        color: transparent;
+      }
+
+      > .loader {
+        opacity: 1;
+      }
+    }
+  }
+
+  &.is-disabled,
+  &[disabled] {
+    opacity: $global-disabled-opacity;
+    cursor: not-allowed;
+    pointer-events: none;
   }
 }

--- a/src/assets/styles/_button.scss
+++ b/src/assets/styles/_button.scss
@@ -83,7 +83,6 @@ $button-icon-enable: true !default;
   // 12. Do not wrap buttons
   // 13. Disable `user-select`
   // 14. Removes inner padding and border in Firefox 4+.
-
   @include selector-placeholder('.button') {
     // 1
     appearance: none;

--- a/src/assets/styles/_container.scss
+++ b/src/assets/styles/_container.scss
@@ -27,4 +27,6 @@ $container-gutter: $global-whitespace-regular !default;
 
     @if (mixin-exists(hook-container)) { @include hook-container(); }
   }
+
+  @if (mixin-exists(hook-container-misc)) { @include hook-container-misc(); }
 }

--- a/src/assets/styles/_form.scss
+++ b/src/assets/styles/_form.scss
@@ -482,7 +482,7 @@ $form-contrast-background-focus: transparent !default;
 
   // 1.Behave like block-level element
   // 2. Style
-  .form-label {
+  @include selector-placeholder('.form-label') {
     // 1
     display: block;
     // 2
@@ -791,7 +791,7 @@ $form-contrast-background-focus: transparent !default;
   // Select
   //
 
-  .form-select {
+  @include selector-placeholder('.form-select') {
     position: relative;
 
     select {

--- a/src/assets/styles/_form.scss
+++ b/src/assets/styles/_form.scss
@@ -482,7 +482,7 @@ $form-contrast-background-focus: transparent !default;
 
   // 1.Behave like block-level element
   // 2. Style
-  @include selector-placeholder('.form-label') {
+  @include selector-placeholder('form-label') {
     // 1
     display: block;
     // 2
@@ -791,7 +791,7 @@ $form-contrast-background-focus: transparent !default;
   // Select
   //
 
-  @include selector-placeholder('.form-select') {
+  @include selector-placeholder('form-select') {
     position: relative;
 
     select {

--- a/src/assets/styles/_functions.scss
+++ b/src/assets/styles/_functions.scss
@@ -20,3 +20,21 @@
 
   @return $result;
 }
+
+//
+// Replace `$search` with `$replace` in `$string`
+// @author Hugo Giraudel
+// @param {String} $string - Initial string
+// @param {String} $search - Substring to replace
+// @param {String} $replace ('') - New value
+// @return {String} - Updated string
+//
+@function str-replace($string, $search, $replace: '') {
+  $index: str-index($string, $search);
+
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+  }
+
+  @return $string;
+}

--- a/src/assets/styles/_functions.scss
+++ b/src/assets/styles/_functions.scss
@@ -20,21 +20,3 @@
 
   @return $result;
 }
-
-//
-// Replace `$search` with `$replace` in `$string`
-// @author Hugo Giraudel
-// @param {String} $string - Initial string
-// @param {String} $search - Substring to replace
-// @param {String} $replace ('') - New value
-// @return {String} - Updated string
-//
-@function str-replace($string, $search, $replace: '') {
-  $index: str-index($string, $search);
-
-  @if $index {
-    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
-  }
-
-  @return $string;
-}

--- a/src/assets/styles/_icons.scss
+++ b/src/assets/styles/_icons.scss
@@ -60,4 +60,6 @@ $icon-vector-effect: non-scaling-stroke !default; // Can turn off with `default`
       stroke-width: $icon-stroke-width-thin;
     }
   }
+
+  @if (mixin-exists(hook-icon-misc)) { @include hook-icon-misc(); }
 }

--- a/src/assets/styles/_inline.scss
+++ b/src/assets/styles/_inline.scss
@@ -62,5 +62,5 @@
     flex-wrap: nowrap;
   }
 
-  @if (mixin-exists(hook-inline)) { @include hook-inline(); }
+  @if (mixin-exists(hook-inline-misc)) { @include hook-inline-misc(); }
 }

--- a/src/assets/styles/_inline.scss
+++ b/src/assets/styles/_inline.scss
@@ -3,7 +3,7 @@
 //
 
 @mixin inline() {
-  @include selector-placeholder('.inline') {
+  @include selector-placeholder('inline') {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -17,7 +17,7 @@
     }
   }
 
-  @include selector-placeholder('.inline--small') {
+  @include selector-placeholder('inline--small') {
     margin-top: (-$global-whitespace-small);
     margin-left: (-$global-whitespace-small);
 
@@ -27,7 +27,7 @@
     }
   }
 
-  @include selector-placeholder('.inline--medium') {
+  @include selector-placeholder('inline--medium') {
     margin-top: (-$global-whitespace-medium);
     margin-left: (-$global-whitespace-medium);
 
@@ -37,7 +37,7 @@
     }
   }
 
-  @include selector-placeholder('.inline--large') {
+  @include selector-placeholder('inline--large') {
     margin-top: (-$global-whitespace-large);
     margin-left: (-$global-whitespace-large);
 
@@ -47,7 +47,7 @@
     }
   }
 
-  @include selector-placeholder('.inline--xlarge') {
+  @include selector-placeholder('inline--xlarge') {
     margin-top: (-$global-whitespace-xlarge);
     margin-left: (-$global-whitespace-xlarge);
 
@@ -57,7 +57,7 @@
     }
   }
 
-  @include selector-placeholder('.inline--noWrap') {
+  @include selector-placeholder('inline--noWrap') {
     white-space: nowrap;
     flex-wrap: nowrap;
   }

--- a/src/assets/styles/_inline.scss
+++ b/src/assets/styles/_inline.scss
@@ -3,7 +3,7 @@
 //
 
 @mixin inline() {
-  .inline {
+  @include selector-placeholder('.inline') {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -15,52 +15,52 @@
       margin-left: $global-whitespace-regular;
       margin-top: $global-whitespace-regular;
     }
-
-    &--small {
-      margin-top: (-$global-whitespace-small);
-      margin-left: (-$global-whitespace-small);
-
-      > * {
-        margin-left: $global-whitespace-small;
-        margin-top: $global-whitespace-small;
-      }
-    }
-
-    &--medium {
-      margin-top: (-$global-whitespace-medium);
-      margin-left: (-$global-whitespace-medium);
-
-      > * {
-        margin-left: $global-whitespace-medium;
-        margin-top: $global-whitespace-medium;
-      }
-    }
-
-    &--large {
-      margin-top: (-$global-whitespace-large);
-      margin-left: (-$global-whitespace-large);
-
-      > * {
-        margin-left: $global-whitespace-large;
-        margin-top: $global-whitespace-large;
-      }
-    }
-
-    &--xlarge {
-      margin-top: (-$global-whitespace-xlarge);
-      margin-left: (-$global-whitespace-xlarge);
-
-      > * {
-        margin-left: $global-whitespace-xlarge;
-        margin-top: $global-whitespace-xlarge;
-      }
-    }
-
-    &--noWrap {
-      white-space: nowrap;
-      flex-wrap: nowrap;
-    }
-
-    @if (mixin-exists(hook-inline)) { @include hook-inline(); }
   }
+
+  @include selector-placeholder('.inline--small') {
+    margin-top: (-$global-whitespace-small);
+    margin-left: (-$global-whitespace-small);
+
+    > * {
+      margin-left: $global-whitespace-small;
+      margin-top: $global-whitespace-small;
+    }
+  }
+
+  @include selector-placeholder('.inline--medium') {
+    margin-top: (-$global-whitespace-medium);
+    margin-left: (-$global-whitespace-medium);
+
+    > * {
+      margin-left: $global-whitespace-medium;
+      margin-top: $global-whitespace-medium;
+    }
+  }
+
+  @include selector-placeholder('.inline--large') {
+    margin-top: (-$global-whitespace-large);
+    margin-left: (-$global-whitespace-large);
+
+    > * {
+      margin-left: $global-whitespace-large;
+      margin-top: $global-whitespace-large;
+    }
+  }
+
+  @include selector-placeholder('.inline--xlarge') {
+    margin-top: (-$global-whitespace-xlarge);
+    margin-left: (-$global-whitespace-xlarge);
+
+    > * {
+      margin-left: $global-whitespace-xlarge;
+      margin-top: $global-whitespace-xlarge;
+    }
+  }
+
+  @include selector-placeholder('.inline--noWrap') {
+    white-space: nowrap;
+    flex-wrap: nowrap;
+  }
+
+  @if (mixin-exists(hook-inline)) { @include hook-inline(); }
 }

--- a/src/assets/styles/_mixins.scss
+++ b/src/assets/styles/_mixins.scss
@@ -24,8 +24,8 @@
 // @param  {string} $class
 //
 @mixin selector-placeholder($class) {
-  .#{$class},
-  %#{$class} {
+  #{$class},
+  %#{str-replace($class, '.')} {
     @content;
   }
 }

--- a/src/assets/styles/_mixins.scss
+++ b/src/assets/styles/_mixins.scss
@@ -21,11 +21,11 @@
 
 //
 // Generates both selector and placeholder equivalent
-// @param  {string} $class
+// @param  {string} $selector
 //
-@mixin selector-placeholder($class) {
-  #{$class},
-  %#{str-replace($class, '.')} {
+@mixin selector-placeholder($selector) {
+  .#{$selector},
+  %#{$selector} {
     @content;
   }
 }
@@ -35,8 +35,8 @@
 // @param  {string} $class
 // @param  {string} $queries: $global-queries
 //
-@mixin breakpoint-selector($class, $sizes: $global-queries) {
-  @include selector-placeholder($class) {
+@mixin breakpoint-selector($selector, $sizes: $global-queries) {
+  @include selector-placeholder($selector) {
     @content;
   }
 
@@ -44,7 +44,7 @@
     $size-index: index($sizes, $size);
 
     @media (min-width: #{$value}) {
-      @include selector-placeholder(#{$class}\@#{$size}) {
+      @include selector-placeholder(#{$selector}\@#{$size}) {
         @content;
       }
     }

--- a/src/assets/styles/_mixins.scss
+++ b/src/assets/styles/_mixins.scss
@@ -1,6 +1,6 @@
 //
 // Iterate through breakpoints to allow for viewport specific styles
-// @param  {string} $selector =
+// @param  {string} $selector
 // @param  {string} $queries: $global-queries
 // @return {mixed}
 //
@@ -13,6 +13,38 @@
   @each $size in $global-breakpoint-sizes {
     #{$selector}#{$breakpoint-delimiter}#{$size} {
       @include queries($size, $global-queries) {
+        @content;
+      }
+    }
+  }
+}
+
+//
+// Generates both selector and placeholder equivalent
+// @param  {string} $class
+//
+@mixin selector-placeholder($class) {
+  .#{$class},
+  %#{$class} {
+    @content;
+  }
+}
+
+//
+// Generates both base selector, breakpoint variants, and placeholder equivalent
+// @param  {string} $class
+// @param  {string} $queries: $global-queries
+//
+@mixin breakpoint-selector($class, $sizes: $global-queries) {
+  @include selector-placeholder($class) {
+    @content;
+  }
+
+  @each $size, $value in $sizes {
+    $size-index: index($sizes, $size);
+
+    @media (min-width: #{$value}) {
+      @include selector-placeholder(#{$class}\@#{$size}) {
         @content;
       }
     }

--- a/src/assets/styles/_section.scss
+++ b/src/assets/styles/_section.scss
@@ -75,8 +75,8 @@ $section-slant-offset: 2.5vw !default;
   }
 
   .section-titleSub {
-    @extend .u-textMuted;
-    @extend .u-textMedium;
+    @extend %u-textMuted;
+    @extend %u-textMedium;
 
     max-width: 625px;
     margin: 0 auto;

--- a/src/assets/styles/_social-icon.scss
+++ b/src/assets/styles/_social-icon.scss
@@ -13,7 +13,7 @@ $social-icon-color: $global-font-color;
 
 @mixin social-icon() {
   // 1. Fix issue with alignment of inlined avatars
-  .socialIcon {
+  @include selector-placeholder(socialIcon) {
     background-color: $social-icon-background;
     border-radius: 50%;
     color: $social-icon-color;
@@ -38,5 +38,7 @@ $social-icon-color: $global-font-color;
       size: $icon-size-large;
       top: auto;
     }
+
+    @if (mixin-exists(hook-social-icon)) { @include hook-social-icon(); }
   }
 }

--- a/src/assets/styles/_social-icon.scss
+++ b/src/assets/styles/_social-icon.scss
@@ -13,7 +13,7 @@ $social-icon-color: $global-font-color;
 
 @mixin social-icon() {
   // 1. Fix issue with alignment of inlined avatars
-  @include selector-placeholder(socialIcon) {
+  .socialIcon {
     background-color: $social-icon-background;
     border-radius: 50%;
     color: $social-icon-color;

--- a/src/assets/styles/_subnav.scss
+++ b/src/assets/styles/_subnav.scss
@@ -11,7 +11,8 @@ $subnav-border: 1px solid $global-border !default;
 //
 
 @mixin subnav() {
-  .subnav-wrapper {
+  .subnav-wrapper,
+  %subnav-wrapper {
     background: $subnav-background;
     border: $subnav-border;
   }
@@ -31,6 +32,8 @@ $subnav-border: 1px solid $global-border !default;
     > * + * {
       margin-left: $global-whitespace-large;
     }
+
+    @if (mixin-exists(hook-subnav)) { @include subnav(); }
   }
 
   .subnav-nav {

--- a/src/assets/styles/_subnav.scss
+++ b/src/assets/styles/_subnav.scss
@@ -11,8 +11,7 @@ $subnav-border: 1px solid $global-border !default;
 //
 
 @mixin subnav() {
-  .subnav-wrapper,
-  %subnav-wrapper {
+  .subnav-wrapper {
     background: $subnav-background;
     border: $subnav-border;
   }
@@ -33,7 +32,7 @@ $subnav-border: 1px solid $global-border !default;
       margin-left: $global-whitespace-large;
     }
 
-    @if (mixin-exists(hook-subnav)) { @include subnav(); }
+    @if (mixin-exists(hook-subnav)) { @include hook-subnav(); }
   }
 
   .subnav-nav {

--- a/src/assets/styles/modules/_docs.scss
+++ b/src/assets/styles/modules/_docs.scss
@@ -33,7 +33,7 @@ $header-mobile-nav-width: 30px;
     }
 
     &.is-active {
-      @include text__underline-styles();
+      @extend %u-textUnderline;
 
       color: $global-font-color;
     }
@@ -143,15 +143,15 @@ $header-mobile-nav-width: 30px;
 blockquote {
   @include trimChildren();
 
-  @extend .alert;
-  @extend .alert--warning;
+  @extend %alert;
+  @extend %alert--warning;
 
   font-style: normal;
   flex-direction: column;
 
   > p:first-of-type:not(:only-child) {
-    @extend .u-textHeading;
-    @extend .u-textFluid--xlarge;
+    @extend %u-textHeading;
+    @extend %u-textFluid--xlarge;
 
     margin-bottom: 0;
   }
@@ -185,8 +185,8 @@ blockquote {
 }
 
 .react-live-error {
-  @extend .alert;
-  @extend .alert--danger;
+  @extend %alert;
+  @extend %alert--danger;
 
   font-family: $base-code-font-family;
 }

--- a/src/assets/styles/modules/_not-found.scss
+++ b/src/assets/styles/modules/_not-found.scss
@@ -1,0 +1,16 @@
+.notFound__wrapper {
+  @extend %u-gradient--darkerBlue-darkestBlue;
+
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.notFound__title {
+  font-size: 25vw !important;
+  background: url('../media/logo-mascot.svg') no-repeat center center;
+  background-size: cover;
+  -webkit-background-clip: text !important;
+  -webkit-text-fill-color: transparent !important;
+}

--- a/src/assets/styles/site.scss
+++ b/src/assets/styles/site.scss
@@ -9,3 +9,4 @@
 //
 
 @import './modules/docs';
+@import './modules/not-found';

--- a/src/assets/styles/utility/_background.scss
+++ b/src/assets/styles/utility/_background.scss
@@ -3,25 +3,25 @@
 //
 
 @mixin background() {
-  @include selector-placeholder('.u-bgPrimary') {
+  @include selector-placeholder('u-bgPrimary') {
     background: $global-primary;
 
     @if (mixin-exists(hook-utility-background-primary)) { @include hook-utility-background-primary(); }
   }
 
-  @include selector-placeholder('.u-bgPrimaryLight') {
+  @include selector-placeholder('u-bgPrimaryLight') {
     background: $global-primary-light;
 
     @if (mixin-exists(hook-utility-background-primary-light)) { @include hook-utility-background-primary-light(); }
   }
 
-  @include selector-placeholder('.u-bgDanger') {
+  @include selector-placeholder('u-bgDanger') {
     background: $global-danger;
 
     @if (mixin-exists(hook-utility-background-danger)) { @include hook-utility-background-danger(); }
   }
 
-  @include selector-placeholder('.u-bgPanel') {
+  @include selector-placeholder('u-bgPanel') {
     background: $global-panel-background;
 
     @if (mixin-exists(hook-utility-background-panel)) { @include hook-utility-background-panel(); }

--- a/src/assets/styles/utility/_background.scss
+++ b/src/assets/styles/utility/_background.scss
@@ -3,29 +3,25 @@
 //
 
 @mixin background() {
-  .u-bgPrimary,
-  %u-bgPrimary {
+  @include selector-placeholder('.u-bgPrimary') {
     background: $global-primary;
 
     @if (mixin-exists(hook-utility-background-primary)) { @include hook-utility-background-primary(); }
   }
 
-  .u-bgPrimaryLight,
-  %u-bgPrimaryLight {
+  @include selector-placeholder('.u-bgPrimaryLight') {
     background: $global-primary-light;
 
     @if (mixin-exists(hook-utility-background-primary-light)) { @include hook-utility-background-primary-light(); }
   }
 
-  .u-bgDanger,
-  %u-bgDanger {
+  @include selector-placeholder('.u-bgDanger') {
     background: $global-danger;
 
     @if (mixin-exists(hook-utility-background-danger)) { @include hook-utility-background-danger(); }
   }
 
-  .u-bgPanel,
-  %u-bgDanger {
+  @include selector-placeholder('.u-bgPanel') {
     background: $global-panel-background;
 
     @if (mixin-exists(hook-utility-background-panel)) { @include hook-utility-background-panel(); }

--- a/src/assets/styles/utility/_background.scss
+++ b/src/assets/styles/utility/_background.scss
@@ -3,31 +3,33 @@
 //
 
 @mixin background() {
-  .u-bg {
-    &Primary {
-      background: $global-primary;
+  .u-bgPrimary,
+  %u-bgPrimary {
+    background: $global-primary;
 
-      @if (mixin-exists(hook-utility-background-primary)) { @include hook-utility-background-primary(); }
-    }
-
-    &PrimaryLight {
-      background: $global-primary-light;
-
-      @if (mixin-exists(hook-utility-background-primary-light)) { @include hook-utility-background-primary-light(); }
-    }
-
-    &Danger {
-      background: $global-danger;
-
-      @if (mixin-exists(hook-utility-background-danger)) { @include hook-utility-background-danger(); }
-    }
-
-    &Panel {
-      background: $global-panel-background;
-
-      @if (mixin-exists(hook-utility-background-panel)) { @include hook-utility-background-panel(); }
-    }
-
-    @if (mixin-exists(hook-utility-background)) { @include hook-utility-background(); }
+    @if (mixin-exists(hook-utility-background-primary)) { @include hook-utility-background-primary(); }
   }
+
+  .u-bgPrimaryLight,
+  %u-bgPrimaryLight {
+    background: $global-primary-light;
+
+    @if (mixin-exists(hook-utility-background-primary-light)) { @include hook-utility-background-primary-light(); }
+  }
+
+  .u-bgDanger,
+  %u-bgDanger {
+    background: $global-danger;
+
+    @if (mixin-exists(hook-utility-background-danger)) { @include hook-utility-background-danger(); }
+  }
+
+  .u-bgPanel,
+  %u-bgDanger {
+    background: $global-panel-background;
+
+    @if (mixin-exists(hook-utility-background-panel)) { @include hook-utility-background-panel(); }
+  }
+
+  @if (mixin-exists(hook-utility-background)) { @include hook-utility-background(); }
 }

--- a/src/assets/styles/utility/_border.scss
+++ b/src/assets/styles/utility/_border.scss
@@ -3,73 +3,71 @@
 //
 
 @mixin border() {
-  .u-border {
-    &Top {
-      border-top: 1px solid $global-border !important;
+  @include selector-placeholder(u-borderTop) {
+    border-top: 1px solid $global-border !important;
 
-      &--remove {
-        border-top: 0 !important;
-      }
+    &--remove {
+      border-top: 0 !important;
     }
+  }
 
-    &Right {
-      border-right: 1px solid $global-border !important;
+  @include selector-placeholder(u-borderRight) {
+    border-right: 1px solid $global-border !important;
 
-      &--remove {
-        border-right: 0 !important;
-      }
+    &--remove {
+      border-right: 0 !important;
     }
+  }
 
-    &Bottom {
-      border-bottom: 1px solid $global-border !important;
+  @include selector-placeholder(u-borderBottom) {
+    border-bottom: 1px solid $global-border !important;
 
-      &--remove {
-        border-bottom: 0 !important;
-      }
+    &--remove {
+      border-bottom: 0 !important;
     }
+  }
 
-    &Left {
-      border-left: 1px solid $global-border !important;
+  @include selector-placeholder(u-borderLeft) {
+    border-left: 1px solid $global-border !important;
 
-      &--remove {
-        border-left: 0 !important;
-      }
+    &--remove {
+      border-left: 0 !important;
     }
+  }
 
-    &Surround {
-      border: 1px solid $global-border !important;
+  @include selector-placeholder(u-borderSurround) {
+    border: 1px solid $global-border !important;
 
-      &--remove {
-        border: 0 !important;
-      }
+    &--remove {
+      border: 0 !important;
     }
+  }
 
-    &Vertical {
-      border-top: 1px solid $global-border !important;
-      border-bottom: 1px solid $global-border !important;
+  @include selector-placeholder(u-borderVertical) {
+    border-top: 1px solid $global-border !important;
+    border-bottom: 1px solid $global-border !important;
 
-      &--remove {
-        border-top: 0 !important;
-        border-bottom: 0 !important;
-      }
+    &--remove {
+      border-top: 0 !important;
+      border-bottom: 0 !important;
     }
+  }
 
-    &Horizontal {
-      border-left: 1px solid $global-border !important;
-      border-right: 1px solid $global-border !important;
+  @include selector-placeholder(u-borderHorizontal) {
+    border-left: 1px solid $global-border !important;
+    border-right: 1px solid $global-border !important;
 
-      &--remove {
-        border-left: 0 !important;
-        border-right: 0 !important;
-      }
+    &--remove {
+      border-left: 0 !important;
+      border-right: 0 !important;
     }
+  }
 
-    &Radius {
-      border-radius: $global-border-radius !important;
+  @include selector-placeholder(u-borderRadius) {
+    border-radius: $global-border-radius !important;
 
-      &--remove {
-        border-radius: 0 !important;
-      }
+    &--remove {
+      border-radius: 0 !important;
     }
   }
 

--- a/src/assets/styles/utility/_border.scss
+++ b/src/assets/styles/utility/_border.scss
@@ -3,7 +3,7 @@
 //
 
 @mixin border() {
-  @include selector-placeholder('.u-borderTop') {
+  @include selector-placeholder('u-borderTop') {
     border-top: 1px solid $global-border !important;
 
     &--remove {
@@ -11,7 +11,7 @@
     }
   }
 
-  @include selector-placeholder('.u-borderRight') {
+  @include selector-placeholder('u-borderRight') {
     border-right: 1px solid $global-border !important;
 
     &--remove {
@@ -19,7 +19,7 @@
     }
   }
 
-  @include selector-placeholder('.u-borderBottom') {
+  @include selector-placeholder('u-borderBottom') {
     border-bottom: 1px solid $global-border !important;
 
     &--remove {
@@ -27,7 +27,7 @@
     }
   }
 
-  @include selector-placeholder('.u-borderLeft') {
+  @include selector-placeholder('u-borderLeft') {
     border-left: 1px solid $global-border !important;
 
     &--remove {
@@ -35,7 +35,7 @@
     }
   }
 
-  @include selector-placeholder('.u-borderSurround') {
+  @include selector-placeholder('u-borderSurround') {
     border: 1px solid $global-border !important;
 
     &--remove {
@@ -43,7 +43,7 @@
     }
   }
 
-  @include selector-placeholder('.u-borderVertical') {
+  @include selector-placeholder('u-borderVertical') {
     border-top: 1px solid $global-border !important;
     border-bottom: 1px solid $global-border !important;
 
@@ -53,7 +53,7 @@
     }
   }
 
-  @include selector-placeholder('.u-borderHorizontal') {
+  @include selector-placeholder('u-borderHorizontal') {
     border-left: 1px solid $global-border !important;
     border-right: 1px solid $global-border !important;
 
@@ -63,7 +63,7 @@
     }
   }
 
-  @include selector-placeholder('.u-borderRadius') {
+  @include selector-placeholder('u-borderRadius') {
     border-radius: $global-border-radius !important;
 
     &--remove {

--- a/src/assets/styles/utility/_border.scss
+++ b/src/assets/styles/utility/_border.scss
@@ -3,7 +3,7 @@
 //
 
 @mixin border() {
-  @include selector-placeholder(u-borderTop) {
+  @include selector-placeholder('.u-borderTop') {
     border-top: 1px solid $global-border !important;
 
     &--remove {
@@ -11,7 +11,7 @@
     }
   }
 
-  @include selector-placeholder(u-borderRight) {
+  @include selector-placeholder('.u-borderRight') {
     border-right: 1px solid $global-border !important;
 
     &--remove {
@@ -19,7 +19,7 @@
     }
   }
 
-  @include selector-placeholder(u-borderBottom) {
+  @include selector-placeholder('.u-borderBottom') {
     border-bottom: 1px solid $global-border !important;
 
     &--remove {
@@ -27,7 +27,7 @@
     }
   }
 
-  @include selector-placeholder(u-borderLeft) {
+  @include selector-placeholder('.u-borderLeft') {
     border-left: 1px solid $global-border !important;
 
     &--remove {
@@ -35,7 +35,7 @@
     }
   }
 
-  @include selector-placeholder(u-borderSurround) {
+  @include selector-placeholder('.u-borderSurround') {
     border: 1px solid $global-border !important;
 
     &--remove {
@@ -43,7 +43,7 @@
     }
   }
 
-  @include selector-placeholder(u-borderVertical) {
+  @include selector-placeholder('.u-borderVertical') {
     border-top: 1px solid $global-border !important;
     border-bottom: 1px solid $global-border !important;
 
@@ -53,7 +53,7 @@
     }
   }
 
-  @include selector-placeholder(u-borderHorizontal) {
+  @include selector-placeholder('.u-borderHorizontal') {
     border-left: 1px solid $global-border !important;
     border-right: 1px solid $global-border !important;
 
@@ -63,7 +63,7 @@
     }
   }
 
-  @include selector-placeholder(u-borderRadius) {
+  @include selector-placeholder('.u-borderRadius') {
     border-radius: $global-border-radius !important;
 
     &--remove {

--- a/src/assets/styles/utility/_contrast.scss
+++ b/src/assets/styles/utility/_contrast.scss
@@ -25,7 +25,7 @@ $contrast-hr-color: rgba($global-contrast, 0.05) !default;
   &:hover,
   &:focus,
   &.is-active {
-    @extend .u-textUnderline;
+    @extend %u-textUnderline;
 
     color: $contrast-link-hover-color !important;
 

--- a/src/assets/styles/utility/_flex.scss
+++ b/src/assets/styles/utility/_flex.scss
@@ -3,7 +3,7 @@
 //
 
 @mixin flex() {
-  @include selector-placeholder(u-flex) {
+  @include selector-placeholder('.u-flex') {
     display: flex;
     list-style: none;
     padding: 0;
@@ -11,7 +11,7 @@
   }
 
   // Child elements automatically match height; this extends that ability to first child element
-  @include selector-placeholder(u-flexDeepMatch) {
+  @include selector-placeholder('.u-flexDeepMatch') {
     > * {
       display: flex;
       flex-wrap: wrap;

--- a/src/assets/styles/utility/_flex.scss
+++ b/src/assets/styles/utility/_flex.scss
@@ -3,163 +3,80 @@
 //
 
 @mixin flex() {
-  .u-flex {
+  @include selector-placeholder(u-flex) {
     display: flex;
     list-style: none;
     padding: 0;
     margin: 0;
+  }
 
-    // Child elements automatically match height; this extends that ability to first child element
-    &DeepMatch {
+  // Child elements automatically match height; this extends that ability to first child element
+  @include selector-placeholder(u-flexDeepMatch) {
+    > * {
+      display: flex;
+      flex-wrap: wrap;
+
       > * {
-        display: flex;
-        flex-wrap: wrap;
-
-        > * {
-          flex: none;
-          width: 100%;
-        }
+        flex: none;
+        width: 100%;
       }
     }
+  }
 
-    // No Flex: 0 0 auto
-    // Content dimensions
-    &ItemNone {
-      flex: none;
-    }
+  // Content dimensions
+  @include breakpoint-selector(u-flexItemNone) {
+    flex: none;
+  }
 
-    // Relative Flex: 1 1 auto
-    // Space is allocated considering content
-    &ItemAuto {
-      flex: auto;
-    }
+  // Space is allocated considering content
+  @include breakpoint-selector(u-flexItemAuto) {
+    flex: auto;
+  }
 
-    // Absolute Flex: 1 1 0%
-    // Space is allocated solely based on flex
-    &Item1 {
-      flex: 1 !important;
-    }
+  // Space is allocated solely based on flex
+  @include breakpoint-selector(u-flexItem1) {
+    flex: 1 !important;
+  }
 
-    &Between {
-      justify-content: space-between !important;
-    }
+  @include breakpoint-selector(u-flexBetween) {
+    justify-content: space-between !important;
+  }
 
-    &Around {
-      justify-content: space-around !important;
-    }
+  @include breakpoint-selector(u-flexAround) {
+    justify-content: space-around !important;
+  }
 
-    //
-    // Alignment modifiers
-    //
+  //
+  // Alignment modifiers
+  //
 
-    // Cross-start margin edge of the items is placed on the cross-start line
-    &Start {
-      justify-content: flex-start !important;
-    }
+  // Cross-start margin edge of the items is placed on the cross-start line
+  @include breakpoint-selector(u-flexStart) {
+    justify-content: flex-start !important;
+  }
 
-    // Items are centered along the line
-    &Center {
-      justify-content: center !important;
-    }
+  // Items are centered along the line
+  @include breakpoint-selector(u-flexCenter) {
+    justify-content: center !important;
+  }
 
-    // Forces row to right
-    &End {
-      justify-content: flex-end !important;
-    }
+  // Forces row to right
+  @include breakpoint-selector(u-flexEnd) {
+    justify-content: flex-end !important;
+  }
 
-    // Cross-start margin edge of the items is placed on the cross-start line
-    &Top {
-      align-items: flex-start !important;
-    }
+  // Cross-start margin edge of the items is placed on the cross-start line
+  @include breakpoint-selector(u-flexTop) {
+    align-items: flex-start !important;
+  }
 
-    // Items are centered in the cross-axis
-    &Middle {
-      align-items: center !important;
-    }
+  // Items are centered in the cross-axis
+  @include breakpoint-selector(u-flexMiddle) {
+    align-items: center !important;
+  }
 
-    // Cross-end margin edge of the items is placed on the cross-end line
-    &Bottom {
-      align-items: flex-end !important;
-    }
-
-    @media (min-width: $global-viewport-small) {
-      &Start\@small {
-        justify-content: flex-start !important;
-      }
-
-      &Center\@small {
-        justify-content: center !important;
-      }
-
-      &End\@small {
-        justify-content: flex-end !important;
-      }
-
-      &Top\@small {
-        align-items: flex-start !important;
-      }
-
-      &Middle\@small {
-        align-items: center !important;
-      }
-
-      &Bottom\@small {
-        align-items: flex-end !important;
-      }
-    }
-
-    @media (min-width: $global-viewport-medium) {
-      &Start\@medium {
-        justify-content: flex-start !important;
-      }
-
-      &Center\@medium {
-        justify-content: center !important;
-      }
-
-      &End\@medium {
-        justify-content: flex-end !important;
-      }
-
-      &Top\@medium {
-        align-items: flex-start !important;
-      }
-
-      &Middle\@medium {
-        align-items: center !important;
-      }
-
-      &Bottom\@medium {
-        align-items: flex-end !important;
-      }
-    }
-
-    @media (min-width: $global-viewport-large) {
-      &Start\@large {
-        justify-content: flex-start !important;
-      }
-
-      &Center\@large {
-        justify-content: center !important;
-      }
-
-      &End\@large {
-        justify-content: flex-end !important;
-      }
-
-      &Top\@large {
-        align-items: flex-start !important;
-      }
-
-      &Middle\@large {
-        align-items: center !important;
-      }
-
-      &Bottom\@large {
-        align-items: flex-end !important;
-      }
-    }
-
-    @if (mixin-exists(hook-utility-flex)) { @include hook-utility-flex(); }
+  // Cross-end margin edge of the items is placed on the cross-end line
+  @include breakpoint-selector(u-flexBottom) {
+    align-items: flex-end !important;
   }
 }

--- a/src/assets/styles/utility/_flex.scss
+++ b/src/assets/styles/utility/_flex.scss
@@ -24,25 +24,25 @@
   }
 
   // Content dimensions
-  @include breakpoint-selector(u-flexItemNone) {
+  @include breakpoint-selector('.u-flexItemNone') {
     flex: none;
   }
 
   // Space is allocated considering content
-  @include breakpoint-selector(u-flexItemAuto) {
+  @include breakpoint-selector('.u-flexItemAuto') {
     flex: auto;
   }
 
   // Space is allocated solely based on flex
-  @include breakpoint-selector(u-flexItem1) {
+  @include breakpoint-selector('.u-flexItem1') {
     flex: 1 !important;
   }
 
-  @include breakpoint-selector(u-flexBetween) {
+  @include breakpoint-selector('.u-flexBetween') {
     justify-content: space-between !important;
   }
 
-  @include breakpoint-selector(u-flexAround) {
+  @include breakpoint-selector('.u-flexAround') {
     justify-content: space-around !important;
   }
 
@@ -51,32 +51,32 @@
   //
 
   // Cross-start margin edge of the items is placed on the cross-start line
-  @include breakpoint-selector(u-flexStart) {
+  @include breakpoint-selector('.u-flexStart') {
     justify-content: flex-start !important;
   }
 
   // Items are centered along the line
-  @include breakpoint-selector(u-flexCenter) {
+  @include breakpoint-selector('.u-flexCenter') {
     justify-content: center !important;
   }
 
   // Forces row to right
-  @include breakpoint-selector(u-flexEnd) {
+  @include breakpoint-selector('.u-flexEnd') {
     justify-content: flex-end !important;
   }
 
   // Cross-start margin edge of the items is placed on the cross-start line
-  @include breakpoint-selector(u-flexTop) {
+  @include breakpoint-selector('.u-flexTop') {
     align-items: flex-start !important;
   }
 
   // Items are centered in the cross-axis
-  @include breakpoint-selector(u-flexMiddle) {
+  @include breakpoint-selector('.u-flexMiddle') {
     align-items: center !important;
   }
 
   // Cross-end margin edge of the items is placed on the cross-end line
-  @include breakpoint-selector(u-flexBottom) {
+  @include breakpoint-selector('.u-flexBottom') {
     align-items: flex-end !important;
   }
 }

--- a/src/assets/styles/utility/_flex.scss
+++ b/src/assets/styles/utility/_flex.scss
@@ -3,7 +3,7 @@
 //
 
 @mixin flex() {
-  @include selector-placeholder('.u-flex') {
+  @include selector-placeholder('u-flex') {
     display: flex;
     list-style: none;
     padding: 0;
@@ -11,7 +11,7 @@
   }
 
   // Child elements automatically match height; this extends that ability to first child element
-  @include selector-placeholder('.u-flexDeepMatch') {
+  @include selector-placeholder('u-flexDeepMatch') {
     > * {
       display: flex;
       flex-wrap: wrap;
@@ -24,25 +24,25 @@
   }
 
   // Content dimensions
-  @include breakpoint-selector('.u-flexItemNone') {
+  @include breakpoint-selector('u-flexItemNone') {
     flex: none;
   }
 
   // Space is allocated considering content
-  @include breakpoint-selector('.u-flexItemAuto') {
+  @include breakpoint-selector('u-flexItemAuto') {
     flex: auto;
   }
 
   // Space is allocated solely based on flex
-  @include breakpoint-selector('.u-flexItem1') {
+  @include breakpoint-selector('u-flexItem1') {
     flex: 1 !important;
   }
 
-  @include breakpoint-selector('.u-flexBetween') {
+  @include breakpoint-selector('u-flexBetween') {
     justify-content: space-between !important;
   }
 
-  @include breakpoint-selector('.u-flexAround') {
+  @include breakpoint-selector('u-flexAround') {
     justify-content: space-around !important;
   }
 
@@ -51,32 +51,32 @@
   //
 
   // Cross-start margin edge of the items is placed on the cross-start line
-  @include breakpoint-selector('.u-flexStart') {
+  @include breakpoint-selector('u-flexStart') {
     justify-content: flex-start !important;
   }
 
   // Items are centered along the line
-  @include breakpoint-selector('.u-flexCenter') {
+  @include breakpoint-selector('u-flexCenter') {
     justify-content: center !important;
   }
 
   // Forces row to right
-  @include breakpoint-selector('.u-flexEnd') {
+  @include breakpoint-selector('u-flexEnd') {
     justify-content: flex-end !important;
   }
 
   // Cross-start margin edge of the items is placed on the cross-start line
-  @include breakpoint-selector('.u-flexTop') {
+  @include breakpoint-selector('u-flexTop') {
     align-items: flex-start !important;
   }
 
   // Items are centered in the cross-axis
-  @include breakpoint-selector('.u-flexMiddle') {
+  @include breakpoint-selector('u-flexMiddle') {
     align-items: center !important;
   }
 
   // Cross-end margin edge of the items is placed on the cross-end line
-  @include breakpoint-selector('.u-flexBottom') {
+  @include breakpoint-selector('u-flexBottom') {
     align-items: flex-end !important;
   }
 }

--- a/src/assets/styles/utility/_gradient.scss
+++ b/src/assets/styles/utility/_gradient.scss
@@ -1,25 +1,25 @@
 @mixin gradient() {
-  .u-gradient--blue-green {
+  @include selector-placeholder(u-gradient--blue-green) {
     background: linear-gradient(to right, $GREMLIN_blue, $GREMLIN_green);
   }
 
-  .u-gradient--teal-darkBlue {
+  @include selector-placeholder(u-gradient--teal-darkBlue) {
     background: linear-gradient(to right, $GREMLIN_teal, $GREMLIN_darkblue);
   }
 
-  .u-gradient--teal-brightTeal {
+  @include selector-placeholder(u-gradient--teal-brightTeal) {
     background: linear-gradient(to right, $GREMLIN_teal, lighten($GREMLIN_teal, 12.5%));
   }
 
-  .u-gradient--green-teal {
+  @include selector-placeholder(u-gradient--green-teal) {
     background: linear-gradient(to right, $GREMLIN_teal, $GREMLIN_green);
   }
 
-  .u-gradient--darkerBlue-darkestBlue {
+  @include selector-placeholder(u-gradient--darkerBlue-darkestBlue) {
     background: linear-gradient(to right, $GREMLIN_darkerblue, $GREMLIN_darkestblue);
   }
 
-  .u-gradient--darkBlue-purple {
+  @include selector-placeholder(u-gradient--darkBlue-purple) {
     background: linear-gradient(to right, $GREMLIN_darkblue, $GREMLIN_purple);
   }
 }

--- a/src/assets/styles/utility/_gradient.scss
+++ b/src/assets/styles/utility/_gradient.scss
@@ -1,25 +1,25 @@
 @mixin gradient() {
-  @include selector-placeholder('.u-gradient--blue-green') {
+  @include selector-placeholder('u-gradient--blue-green') {
     background: linear-gradient(to right, $GREMLIN_blue, $GREMLIN_green);
   }
 
-  @include selector-placeholder('.u-gradient--teal-darkBlue') {
+  @include selector-placeholder('u-gradient--teal-darkBlue') {
     background: linear-gradient(to right, $GREMLIN_teal, $GREMLIN_darkblue);
   }
 
-  @include selector-placeholder('.u-gradient--teal-brightTeal') {
+  @include selector-placeholder('u-gradient--teal-brightTeal') {
     background: linear-gradient(to right, $GREMLIN_teal, lighten($GREMLIN_teal, 12.5%));
   }
 
-  @include selector-placeholder('.u-gradient--green-teal') {
+  @include selector-placeholder('u-gradient--green-teal') {
     background: linear-gradient(to right, $GREMLIN_teal, $GREMLIN_green);
   }
 
-  @include selector-placeholder('.u-gradient--darkerBlue-darkestBlue') {
+  @include selector-placeholder('u-gradient--darkerBlue-darkestBlue') {
     background: linear-gradient(to right, $GREMLIN_darkerblue, $GREMLIN_darkestblue);
   }
 
-  @include selector-placeholder('.u-gradient--darkBlue-purple') {
+  @include selector-placeholder('u-gradient--darkBlue-purple') {
     background: linear-gradient(to right, $GREMLIN_darkblue, $GREMLIN_purple);
   }
 }

--- a/src/assets/styles/utility/_gradient.scss
+++ b/src/assets/styles/utility/_gradient.scss
@@ -1,25 +1,25 @@
 @mixin gradient() {
-  @include selector-placeholder(u-gradient--blue-green) {
+  @include selector-placeholder('.u-gradient--blue-green') {
     background: linear-gradient(to right, $GREMLIN_blue, $GREMLIN_green);
   }
 
-  @include selector-placeholder(u-gradient--teal-darkBlue) {
+  @include selector-placeholder('.u-gradient--teal-darkBlue') {
     background: linear-gradient(to right, $GREMLIN_teal, $GREMLIN_darkblue);
   }
 
-  @include selector-placeholder(u-gradient--teal-brightTeal) {
+  @include selector-placeholder('.u-gradient--teal-brightTeal') {
     background: linear-gradient(to right, $GREMLIN_teal, lighten($GREMLIN_teal, 12.5%));
   }
 
-  @include selector-placeholder(u-gradient--green-teal) {
+  @include selector-placeholder('.u-gradient--green-teal') {
     background: linear-gradient(to right, $GREMLIN_teal, $GREMLIN_green);
   }
 
-  @include selector-placeholder(u-gradient--darkerBlue-darkestBlue) {
+  @include selector-placeholder('.u-gradient--darkerBlue-darkestBlue') {
     background: linear-gradient(to right, $GREMLIN_darkerblue, $GREMLIN_darkestblue);
   }
 
-  @include selector-placeholder(u-gradient--darkBlue-purple) {
+  @include selector-placeholder('.u-gradient--darkBlue-purple') {
     background: linear-gradient(to right, $GREMLIN_darkblue, $GREMLIN_purple);
   }
 }

--- a/src/assets/styles/utility/_list.scss
+++ b/src/assets/styles/utility/_list.scss
@@ -31,52 +31,51 @@
 }
 
 @mixin list() {
-  // Unordered list with no bullets
-  .u-list {
+  @include selector-placeholder(u-list) {
     list-style: none;
     padding-left: 0;
-
-    &--space {
-      > * {
-        + * {
-          margin-top: $global-whitespace-regular;
-        }
-      }
-    }
-
-    &--border {
-      > * {
-        padding-top: $global-whitespace-large;
-        padding-bottom: $global-whitespace-large;
-
-        + * {
-          border-top: 1px solid $global-border;
-        }
-      }
-    }
-
-    &--circles {
-      > li {
-        @include list_circles();
-      }
-    }
-
-    &--number {
-      counter-reset: list-counter;
-
-      > li {
-        list-style: none;
-
-        &::before {
-          content: counter(list-counter, decimal);
-          counter-increment: list-counter;
-          margin-right: $global-whitespace-small;
-          font-weight: $global-font-weight-bold;
-          color: $global-primary;
-        }
-      }
-    }
-
-    @if (mixin-exists(hook-utility-list)) { @include hook-utility-list(); }
   }
+
+  @include selector-placeholder(u-list--space) {
+    > * {
+      + * {
+        margin-top: $global-whitespace-regular;
+      }
+    }
+  }
+
+  @include selector-placeholder(u-list--border) {
+    > * {
+      padding-top: $global-whitespace-large;
+      padding-bottom: $global-whitespace-large;
+
+      + * {
+        border-top: 1px solid $global-border;
+      }
+    }
+  }
+
+  @include selector-placeholder(u-list--circles) {
+    > li {
+      @include list_circles();
+    }
+  }
+
+  @include selector-placeholder(u-list--number) {
+    counter-reset: list-counter;
+
+    > li {
+      list-style: none;
+
+      &::before {
+        content: counter(list-counter, decimal);
+        counter-increment: list-counter;
+        margin-right: $global-whitespace-small;
+        font-weight: $global-font-weight-bold;
+        color: $global-primary;
+      }
+    }
+  }
+
+  @if (mixin-exists(hook-utility-list)) { @include hook-utility-list(); }
 }

--- a/src/assets/styles/utility/_list.scss
+++ b/src/assets/styles/utility/_list.scss
@@ -31,12 +31,12 @@
 }
 
 @mixin list() {
-  @include selector-placeholder('.u-list') {
+  @include selector-placeholder('u-list') {
     list-style: none;
     padding-left: 0;
   }
 
-  @include selector-placeholder('.u-list--space') {
+  @include selector-placeholder('u-list--space') {
     > * {
       + * {
         margin-top: $global-whitespace-regular;
@@ -44,7 +44,7 @@
     }
   }
 
-  @include selector-placeholder('.u-list--border') {
+  @include selector-placeholder('u-list--border') {
     > * {
       padding-top: $global-whitespace-large;
       padding-bottom: $global-whitespace-large;
@@ -55,13 +55,13 @@
     }
   }
 
-  @include selector-placeholder('.u-list--circles') {
+  @include selector-placeholder('u-list--circles') {
     > li {
       @include list_circles();
     }
   }
 
-  @include selector-placeholder('.u-list--number') {
+  @include selector-placeholder('u-list--number') {
     counter-reset: list-counter;
 
     > li {

--- a/src/assets/styles/utility/_list.scss
+++ b/src/assets/styles/utility/_list.scss
@@ -31,12 +31,12 @@
 }
 
 @mixin list() {
-  @include selector-placeholder(u-list) {
+  @include selector-placeholder('.u-list') {
     list-style: none;
     padding-left: 0;
   }
 
-  @include selector-placeholder(u-list--space) {
+  @include selector-placeholder('.u-list--space') {
     > * {
       + * {
         margin-top: $global-whitespace-regular;
@@ -44,7 +44,7 @@
     }
   }
 
-  @include selector-placeholder(u-list--border) {
+  @include selector-placeholder('.u-list--border') {
     > * {
       padding-top: $global-whitespace-large;
       padding-bottom: $global-whitespace-large;
@@ -55,13 +55,13 @@
     }
   }
 
-  @include selector-placeholder(u-list--circles) {
+  @include selector-placeholder('.u-list--circles') {
     > li {
       @include list_circles();
     }
   }
 
-  @include selector-placeholder(u-list--number) {
+  @include selector-placeholder('.u-list--number') {
     counter-reset: list-counter;
 
     > li {

--- a/src/assets/styles/utility/_text.scss
+++ b/src/assets/styles/utility/_text.scss
@@ -3,31 +3,31 @@
 //
 
 @mixin text() {
-  @include selector-placeholder('.u-textXsmall') {
+  @include selector-placeholder('u-textXsmall') {
     font-size: $global-font-size-xsmall !important;
   }
 
-  @include selector-placeholder('.u-textSmall') {
+  @include selector-placeholder('u-textSmall') {
     font-size: $global-font-size-small !important;
   }
 
-  @include selector-placeholder('.u-textRegular') {
+  @include selector-placeholder('u-textRegular') {
     font-size: $global-font-size !important;
   }
 
-  @include selector-placeholder('.u-textMedium') {
+  @include selector-placeholder('u-textMedium') {
     font-size: $global-font-size-medium !important;
   }
 
-  @include selector-placeholder('.u-textLarge') {
+  @include selector-placeholder('u-textLarge') {
     font-size: $global-font-size-large !important;
   }
 
-  @include selector-placeholder('.u-textXlarge') {
+  @include selector-placeholder('u-textXlarge') {
     font-size: $global-font-size-xlarge !important;
   }
 
-  @include selector-placeholder('.u-textHeading') {
+  @include selector-placeholder('u-textHeading') {
     font-family: $base-heading-font-family !important;
     font-weight: $global-font-weight-bold !important;
     text-transform: $base-heading-text-transform !important;
@@ -35,121 +35,121 @@
     line-height: $base-heading-line-height !important;
   }
 
-  @include selector-placeholder('.u-textFluid--h1-h2') {
+  @include selector-placeholder('u-textFluid--h1-h2') {
     @include fluid-type($base-h2-font-size, $base-h1-font-size);
   }
 
-  @include selector-placeholder('.u-textFluid--h2-h3') {
+  @include selector-placeholder('u-textFluid--h2-h3') {
     @include fluid-type($base-h3-font-size, $base-h2-font-size);
   }
 
-  @include selector-placeholder('.u-textFluid--h3-h4') {
+  @include selector-placeholder('u-textFluid--h3-h4') {
     @include fluid-type($base-h4-font-size, $base-h3-font-size);
   }
 
-  @include selector-placeholder('.u-textFluid--medium') {
+  @include selector-placeholder('u-textFluid--medium') {
     @include fluid-type($global-font-size, $global-font-size-medium);
   }
 
-  @include selector-placeholder('.u-textFluid--large') {
+  @include selector-placeholder('u-textFluid--large') {
     @include fluid-type($global-font-size, $global-font-size-large);
   }
 
-  @include selector-placeholder('.u-textFluid--xlarge') {
+  @include selector-placeholder('u-textFluid--xlarge') {
     @include fluid-type($global-font-size-large, $global-font-size-xlarge);
   }
 
-  @include selector-placeholder('.u-textNormal') {
+  @include selector-placeholder('u-textNormal') {
     font-weight: $global-font-weight !important;
   }
 
-  @include selector-placeholder('.u-textMediumWeight') {
+  @include selector-placeholder('u-textMediumWeight') {
     font-weight: $global-font-weight-medium !important;
   }
 
-  @include selector-placeholder('.u-textItalic') {
+  @include selector-placeholder('u-textItalic') {
     font-style: italic !important;
   }
 
-  @include selector-placeholder('.u-textBold') {
+  @include selector-placeholder('u-textBold') {
     font-weight: $global-font-weight-bold !important;
   }
 
-  @include selector-placeholder('.u-textDefault') {
+  @include selector-placeholder('u-textDefault') {
     color: $global-font-color !important;
   }
 
-  @include selector-placeholder('.u-textHDefault') {
+  @include selector-placeholder('u-textHDefault') {
     color: $global-heading-color !important;
   }
 
-  @include selector-placeholder('.u-textPrimary') {
+  @include selector-placeholder('u-textPrimary') {
     color: $global-primary !important;
   }
 
-  @include selector-placeholder('.u-textTeal') {
+  @include selector-placeholder('u-textTeal') {
     color: $GREMLIN_teal;
   }
 
-  @include selector-placeholder('.u-textDanger') {
+  @include selector-placeholder('u-textDanger') {
     color: $global-danger !important;
   }
 
-  @include selector-placeholder('.u-textContrast') {
+  @include selector-placeholder('u-textContrast') {
     color: $global-contrast !important;
   }
 
-  @include selector-placeholder('.u-textMuted') {
+  @include selector-placeholder('u-textMuted') {
     color: $global-muted !important;
   }
 
-  @include selector-placeholder('.u-textUnderline') {
+  @include selector-placeholder('u-textUnderline') {
     text-decoration: underline !important;
     text-decoration-skip: ink;
   }
 
   // Prevent text from wrapping onto multiple lines, and truncate with an ellipsis
-  @include selector-placeholder('.u-textTruncate') {
+  @include selector-placeholder('u-textTruncate') {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   // Break strings if their length exceeds the width of their container
-  @include selector-placeholder('.u-textBreak') {
+  @include selector-placeholder('u-textBreak') {
     hyphens: auto;
     word-wrap: break-word;
   }
 
   // Prevents text from wrapping into multiple lines
-  @include selector-placeholder('.u-textNoBreak') {
+  @include selector-placeholder('u-textNoBreak') {
     white-space: nowrap !important;
   }
 
-  @include selector-placeholder('.u-textUppercase') {
+  @include selector-placeholder('u-textUppercase') {
     text-transform: uppercase !important;
   }
 
   // Overrides line-height for sub-text on wrapping lines
-  @include selector-placeholder('.u-textSub') {
+  @include selector-placeholder('u-textSub') {
     line-height: $global-line-height-small !important;
   }
 
-  @include breakpoint-selector('.u-textLeft') {
+  @include breakpoint-selector('u-textLeft') {
     text-align: left !important;
   }
 
-  @include breakpoint-selector('.u-textCenter') {
+  @include breakpoint-selector('u-textCenter') {
     text-align: center !important;
   }
 
-  @include breakpoint-selector('.u-textRight') {
+  @include breakpoint-selector('u-textRight') {
     text-align: right !important;
   }
 
   @if (mixin-exists(hook-utility-text)) { @include hook-utility-text(); }
 
-  @include selector-placeholder('.u-link') {
+  @include selector-placeholder('u-link') {
     color: $global-primary !important;
 
     &:hover,
@@ -159,7 +159,7 @@
     }
   }
 
-  @include selector-placeholder('.u-linkDefault') {
+  @include selector-placeholder('u-linkDefault') {
     color: $global-font-color !important;
 
     &:hover,
@@ -169,11 +169,11 @@
     }
   }
 
-  @include selector-placeholder('.u-linkContrast') {
+  @include selector-placeholder('u-linkContrast') {
     @include contrast-link-styles();
   }
 
-  @include selector-placeholder('.u-linkMuted') {
+  @include selector-placeholder('u-linkMuted') {
     color: $global-muted !important;
 
     &:hover,
@@ -183,7 +183,7 @@
     }
   }
 
-  @include selector-placeholder('.u-linkHeading') {
+  @include selector-placeholder('u-linkHeading') {
     color: $global-heading-color !important;
 
     &:hover,
@@ -193,7 +193,7 @@
     }
   }
 
-  @include selector-placeholder('.u-linkUnderline') {
+  @include selector-placeholder('u-linkUnderline') {
     &:hover,
     &:focus,
     &:active {

--- a/src/assets/styles/utility/_text.scss
+++ b/src/assets/styles/utility/_text.scss
@@ -3,31 +3,31 @@
 //
 
 @mixin text() {
-  @include selector-placeholder(u-textXsmall) {
+  @include selector-placeholder('.u-textXsmall') {
     font-size: $global-font-size-xsmall !important;
   }
 
-  @include selector-placeholder(u-textSmall) {
+  @include selector-placeholder('.u-textSmall') {
     font-size: $global-font-size-small !important;
   }
 
-  @include selector-placeholder(u-textRegular) {
+  @include selector-placeholder('.u-textRegular') {
     font-size: $global-font-size !important;
   }
 
-  @include selector-placeholder(u-textMedium) {
+  @include selector-placeholder('.u-textMedium') {
     font-size: $global-font-size-medium !important;
   }
 
-  @include selector-placeholder(u-textLarge) {
+  @include selector-placeholder('.u-textLarge') {
     font-size: $global-font-size-large !important;
   }
 
-  @include selector-placeholder(u-textXlarge) {
+  @include selector-placeholder('.u-textXlarge') {
     font-size: $global-font-size-xlarge !important;
   }
 
-  @include selector-placeholder(u-textHeading) {
+  @include selector-placeholder('.u-textHeading') {
     font-family: $base-heading-font-family !important;
     font-weight: $global-font-weight-bold !important;
     text-transform: $base-heading-text-transform !important;
@@ -35,103 +35,103 @@
     line-height: $base-heading-line-height !important;
   }
 
-  @include selector-placeholder(u-textFluid--h1-h2) {
+  @include selector-placeholder('.u-textFluid--h1-h2') {
     @include fluid-type($base-h2-font-size, $base-h1-font-size);
   }
 
-  @include selector-placeholder(u-textFluid--h2-h3) {
+  @include selector-placeholder('.u-textFluid--h2-h3') {
     @include fluid-type($base-h3-font-size, $base-h2-font-size);
   }
 
-  @include selector-placeholder(u-textFluid--h3-h4) {
+  @include selector-placeholder('.u-textFluid--h3-h4') {
     @include fluid-type($base-h4-font-size, $base-h3-font-size);
   }
 
-  @include selector-placeholder(u-textFluid--medium) {
+  @include selector-placeholder('.u-textFluid--medium') {
     @include fluid-type($global-font-size, $global-font-size-medium);
   }
 
-  @include selector-placeholder(u-textFluid--large) {
+  @include selector-placeholder('.u-textFluid--large') {
     @include fluid-type($global-font-size, $global-font-size-large);
   }
 
-  @include selector-placeholder(u-textFluid--xlarge) {
+  @include selector-placeholder('.u-textFluid--xlarge') {
     @include fluid-type($global-font-size-large, $global-font-size-xlarge);
   }
 
-  @include selector-placeholder(u-textNormal) {
+  @include selector-placeholder('.u-textNormal') {
     font-weight: $global-font-weight !important;
   }
 
-  @include selector-placeholder(u-textMediumWeight) {
+  @include selector-placeholder('.u-textMediumWeight') {
     font-weight: $global-font-weight-medium !important;
   }
 
-  @include selector-placeholder(u-textItalic) {
+  @include selector-placeholder('.u-textItalic') {
     font-style: italic !important;
   }
 
-  @include selector-placeholder(u-textBold) {
+  @include selector-placeholder('.u-textBold') {
     font-weight: $global-font-weight-bold !important;
   }
 
-  @include selector-placeholder(u-textDefault) {
+  @include selector-placeholder('.u-textDefault') {
     color: $global-font-color !important;
   }
 
-  @include selector-placeholder(u-textHDefault) {
+  @include selector-placeholder('.u-textHDefault') {
     color: $global-heading-color !important;
   }
 
-  @include selector-placeholder(u-textPrimary) {
+  @include selector-placeholder('.u-textPrimary') {
     color: $global-primary !important;
   }
 
-  @include selector-placeholder(u-textTeal) {
+  @include selector-placeholder('.u-textTeal') {
     color: $GREMLIN_teal;
   }
 
-  @include selector-placeholder(u-textDanger) {
+  @include selector-placeholder('.u-textDanger') {
     color: $global-danger !important;
   }
 
-  @include selector-placeholder(u-textContrast) {
+  @include selector-placeholder('.u-textContrast') {
     color: $global-contrast !important;
   }
 
-  @include selector-placeholder(u-textMuted) {
+  @include selector-placeholder('.u-textMuted') {
     color: $global-muted !important;
   }
 
-  @include selector-placeholder(u-textUnderline) {
+  @include selector-placeholder('.u-textUnderline') {
     text-decoration: underline !important;
     text-decoration-skip: ink;
   }
 
   // Prevent text from wrapping onto multiple lines, and truncate with an ellipsis
-  @include selector-placeholder(u-textTruncate) {
+  @include selector-placeholder('.u-textTruncate') {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   // Break strings if their length exceeds the width of their container
-  @include selector-placeholder(u-textBreak) {
+  @include selector-placeholder('.u-textBreak') {
     hyphens: auto;
     word-wrap: break-word;
   }
 
   // Prevents text from wrapping into multiple lines
-  @include selector-placeholder(u-textNoBreak) {
+  @include selector-placeholder('.u-textNoBreak') {
     white-space: nowrap !important;
   }
 
-  @include selector-placeholder(u-textUppercase) {
+  @include selector-placeholder('.u-textUppercase') {
     text-transform: uppercase !important;
   }
 
   // Overrides line-height for sub-text on wrapping lines
-  @include selector-placeholder(u-textSub) {
+  @include selector-placeholder('.u-textSub') {
     line-height: $global-line-height-small !important;
   }
 
@@ -149,7 +149,7 @@
 
   @if (mixin-exists(hook-utility-text)) { @include hook-utility-text(); }
 
-  @include selector-placeholder(u-link) {
+  @include selector-placeholder('.u-link') {
     color: $global-primary !important;
 
     &:hover,
@@ -159,7 +159,7 @@
     }
   }
 
-  @include selector-placeholder(u-linkDefault) {
+  @include selector-placeholder('.u-linkDefault') {
     color: $global-font-color !important;
 
     &:hover,
@@ -169,11 +169,11 @@
     }
   }
 
-  @include selector-placeholder(u-linkContrast) {
+  @include selector-placeholder('.u-linkContrast') {
     @include contrast-link-styles();
   }
 
-  @include selector-placeholder(u-linkMuted) {
+  @include selector-placeholder('.u-linkMuted') {
     color: $global-muted !important;
 
     &:hover,
@@ -183,7 +183,7 @@
     }
   }
 
-  @include selector-placeholder(u-linkHeading) {
+  @include selector-placeholder('.u-linkHeading') {
     color: $global-heading-color !important;
 
     &:hover,
@@ -193,7 +193,7 @@
     }
   }
 
-  @include selector-placeholder(u-linkUnderline) {
+  @include selector-placeholder('.u-linkUnderline') {
     &:hover,
     &:focus,
     &:active {

--- a/src/assets/styles/utility/_text.scss
+++ b/src/assets/styles/utility/_text.scss
@@ -135,15 +135,15 @@
     line-height: $global-line-height-small !important;
   }
 
-  @include breakpoint-selector(u-textLeft) {
+  @include breakpoint-selector('.u-textLeft') {
     text-align: left !important;
   }
 
-  @include breakpoint-selector(u-textCenter) {
+  @include breakpoint-selector('.u-textCenter') {
     text-align: center !important;
   }
 
-  @include breakpoint-selector(u-textRight) {
+  @include breakpoint-selector('.u-textRight') {
     text-align: right !important;
   }
 

--- a/src/assets/styles/utility/_text.scss
+++ b/src/assets/styles/utility/_text.scss
@@ -2,202 +2,154 @@
 // Component
 //
 
-@mixin text__underline-styles() {
-  text-decoration: underline !important;
-  text-decoration-skip: ink;
-}
-
 @mixin text() {
-  .u-text {
-    &Xsmall {
-      font-size: $global-font-size-xsmall !important;
-    }
-
-    &Small {
-      font-size: $global-font-size-small !important;
-    }
-
-    &Regular {
-      font-size: $global-font-size !important;
-    }
-
-    &Medium {
-      font-size: $global-font-size-medium !important;
-    }
-
-    &Large {
-      font-size: $global-font-size-large !important;
-    }
-
-    &Xlarge {
-      font-size: $global-font-size-xlarge !important;
-    }
-
-    &Heading {
-      font-family: $base-heading-font-family !important;
-      font-weight: $global-font-weight-bold !important;
-      text-transform: $base-heading-text-transform !important;
-      letter-spacing: $base-heading-letter-spacing !important;
-      line-height: $base-heading-line-height !important;
-    }
-
-    &Fluid--h1-h2 {
-      @include fluid-type($base-h2-font-size, $base-h1-font-size);
-    }
-
-    &Fluid--h2-h3 {
-      @include fluid-type($base-h3-font-size, $base-h2-font-size);
-    }
-
-    &Fluid--h3-h4 {
-      @include fluid-type($base-h4-font-size, $base-h3-font-size);
-    }
-
-    &Fluid--medium {
-      @include fluid-type($global-font-size, $global-font-size-medium);
-    }
-
-    &Fluid--large {
-      @include fluid-type($global-font-size, $global-font-size-large);
-    }
-
-    &Fluid--xlarge {
-      @include fluid-type($global-font-size-large, $global-font-size-xlarge);
-    }
-
-    &Normal {
-      font-weight: $global-font-weight !important;
-    }
-
-    &MediumWeight {
-      font-weight: $global-font-weight-medium !important;
-    }
-
-    &Italic {
-      font-style: italic !important;
-    }
-
-    &Bold {
-      font-weight: $global-font-weight-bold !important;
-    }
-
-    &Default {
-      color: $global-font-color !important;
-    }
-
-    &HDefault {
-      color: $global-heading-color !important;
-    }
-
-    &Primary {
-      color: $global-primary !important;
-    }
-
-    &Teal {
-      color: $GREMLIN_teal;
-    }
-
-    &Danger {
-      color: $global-danger !important;
-    }
-
-    &Contrast {
-      color: $global-contrast !important;
-    }
-
-    &Muted {
-      color: $global-muted !important;
-    }
-
-    &Underline {
-      @include text__underline-styles();
-    }
-
-    // Prevent text from wrapping onto multiple lines, and truncate with an ellipsis
-    &Truncate {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    // Break strings if their length exceeds the width of their container
-    &Break {
-      hyphens: auto;
-      word-wrap: break-word;
-    }
-
-    // Prevents text from wrapping into multiple lines
-    &NoBreak {
-      white-space: nowrap !important;
-    }
-
-    &Uppercase {
-      text-transform: uppercase !important;
-    }
-
-    // Overrides line-height for sub-text on wrapping lines
-    &Sub {
-      line-height: $global-line-height-small !important;
-    }
-
-    &Left {
-      text-align: left !important;
-    }
-
-    &Center {
-      text-align: center !important;
-    }
-
-    &Right {
-      text-align: right !important;
-    }
-
-    @media (min-width: $global-viewport-small) {
-      &Left\@small {
-        text-align: left !important;
-      }
-
-      &Center\@small {
-        text-align: center !important;
-      }
-
-      &Right\@small {
-        text-align: right !important;
-      }
-    }
-
-    @media (min-width: $global-viewport-medium) {
-      &Left\@medium {
-        text-align: left !important;
-      }
-
-      &Center\@medium {
-        text-align: center !important;
-      }
-
-      &Right\@medium {
-        text-align: right !important;
-      }
-    }
-
-    @media (min-width: $global-viewport-large) {
-      &Left\@large {
-        text-align: left !important;
-      }
-
-      &Center\@large {
-        text-align: center !important;
-      }
-
-      &Right\@large {
-        text-align: right !important;
-      }
-    }
-
-    @if (mixin-exists(hook-utility-text)) { @include hook-utility-text(); }
+  @include selector-placeholder(u-textXsmall) {
+    font-size: $global-font-size-xsmall !important;
   }
 
-  .u-link {
+  @include selector-placeholder(u-textSmall) {
+    font-size: $global-font-size-small !important;
+  }
+
+  @include selector-placeholder(u-textRegular) {
+    font-size: $global-font-size !important;
+  }
+
+  @include selector-placeholder(u-textMedium) {
+    font-size: $global-font-size-medium !important;
+  }
+
+  @include selector-placeholder(u-textLarge) {
+    font-size: $global-font-size-large !important;
+  }
+
+  @include selector-placeholder(u-textXlarge) {
+    font-size: $global-font-size-xlarge !important;
+  }
+
+  @include selector-placeholder(u-textHeading) {
+    font-family: $base-heading-font-family !important;
+    font-weight: $global-font-weight-bold !important;
+    text-transform: $base-heading-text-transform !important;
+    letter-spacing: $base-heading-letter-spacing !important;
+    line-height: $base-heading-line-height !important;
+  }
+
+  @include selector-placeholder(u-textFluid--h1-h2) {
+    @include fluid-type($base-h2-font-size, $base-h1-font-size);
+  }
+
+  @include selector-placeholder(u-textFluid--h2-h3) {
+    @include fluid-type($base-h3-font-size, $base-h2-font-size);
+  }
+
+  @include selector-placeholder(u-textFluid--h3-h4) {
+    @include fluid-type($base-h4-font-size, $base-h3-font-size);
+  }
+
+  @include selector-placeholder(u-textFluid--medium) {
+    @include fluid-type($global-font-size, $global-font-size-medium);
+  }
+
+  @include selector-placeholder(u-textFluid--large) {
+    @include fluid-type($global-font-size, $global-font-size-large);
+  }
+
+  @include selector-placeholder(u-textFluid--xlarge) {
+    @include fluid-type($global-font-size-large, $global-font-size-xlarge);
+  }
+
+  @include selector-placeholder(u-textNormal) {
+    font-weight: $global-font-weight !important;
+  }
+
+  @include selector-placeholder(u-textMediumWeight) {
+    font-weight: $global-font-weight-medium !important;
+  }
+
+  @include selector-placeholder(u-textItalic) {
+    font-style: italic !important;
+  }
+
+  @include selector-placeholder(u-textBold) {
+    font-weight: $global-font-weight-bold !important;
+  }
+
+  @include selector-placeholder(u-textDefault) {
+    color: $global-font-color !important;
+  }
+
+  @include selector-placeholder(u-textHDefault) {
+    color: $global-heading-color !important;
+  }
+
+  @include selector-placeholder(u-textPrimary) {
+    color: $global-primary !important;
+  }
+
+  @include selector-placeholder(u-textTeal) {
+    color: $GREMLIN_teal;
+  }
+
+  @include selector-placeholder(u-textDanger) {
+    color: $global-danger !important;
+  }
+
+  @include selector-placeholder(u-textContrast) {
+    color: $global-contrast !important;
+  }
+
+  @include selector-placeholder(u-textMuted) {
+    color: $global-muted !important;
+  }
+
+  @include selector-placeholder(u-textUnderline) {
+    text-decoration: underline !important;
+    text-decoration-skip: ink;
+  }
+
+  // Prevent text from wrapping onto multiple lines, and truncate with an ellipsis
+  @include selector-placeholder(u-textTruncate) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // Break strings if their length exceeds the width of their container
+  @include selector-placeholder(u-textBreak) {
+    hyphens: auto;
+    word-wrap: break-word;
+  }
+
+  // Prevents text from wrapping into multiple lines
+  @include selector-placeholder(u-textNoBreak) {
+    white-space: nowrap !important;
+  }
+
+  @include selector-placeholder(u-textUppercase) {
+    text-transform: uppercase !important;
+  }
+
+  // Overrides line-height for sub-text on wrapping lines
+  @include selector-placeholder(u-textSub) {
+    line-height: $global-line-height-small !important;
+  }
+
+  @include breakpoint-selector(u-textLeft) {
+    text-align: left !important;
+  }
+
+  @include breakpoint-selector(u-textCenter) {
+    text-align: center !important;
+  }
+
+  @include breakpoint-selector(u-textRight) {
+    text-align: right !important;
+  }
+
+  @if (mixin-exists(hook-utility-text)) { @include hook-utility-text(); }
+
+  @include selector-placeholder(u-link) {
     color: $global-primary !important;
 
     &:hover,
@@ -205,50 +157,50 @@
     &:active {
       color: $global-primary-hover !important;
     }
-
-    &Default {
-      color: $global-font-color !important;
-
-      &:hover,
-      &:focus,
-      &:active {
-        color: $global-font-color !important;
-      }
-    }
-
-    &Contrast {
-      @include contrast-link-styles();
-    }
-
-    &Muted {
-      color: $global-muted !important;
-
-      &:hover,
-      &:focus,
-      &:active {
-        color: darken($global-muted, 10) !important;
-      }
-    }
-
-    &Heading {
-      color: $global-heading-color !important;
-
-      &:hover,
-      &:focus,
-      &:active {
-        color: darken($global-heading-color, 5) !important;
-      }
-    }
-
-    &Underline {
-      &:hover,
-      &:focus,
-      &:active {
-        text-decoration: underline !important;
-        text-decoration-skip: ink;
-      }
-    }
-
-    @if (mixin-exists(hook-utility-link)) { @include hook-utility-link(); }
   }
+
+  @include selector-placeholder(u-linkDefault) {
+    color: $global-font-color !important;
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: $global-font-color !important;
+    }
+  }
+
+  @include selector-placeholder(u-linkContrast) {
+    @include contrast-link-styles();
+  }
+
+  @include selector-placeholder(u-linkMuted) {
+    color: $global-muted !important;
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: darken($global-muted, 10) !important;
+    }
+  }
+
+  @include selector-placeholder(u-linkHeading) {
+    color: $global-heading-color !important;
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: darken($global-heading-color, 5) !important;
+    }
+  }
+
+  @include selector-placeholder(u-linkUnderline) {
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: underline !important;
+      text-decoration-skip: ink;
+    }
+  }
+
+  @if (mixin-exists(hook-utility-link)) { @include hook-utility-link(); }
 }

--- a/src/layouts/BaseLayout.js
+++ b/src/layouts/BaseLayout.js
@@ -1,0 +1,204 @@
+import React from 'react';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
+import 'what-input';
+
+import Foundation from './Foundation';
+import { styles } from '../helpers/styles';
+import { config } from '../helpers/config';
+import { Button, Icon, Inline, List, ListItem } from '../components';
+import { version } from '../../package.json';
+
+import mascot from '../assets/media/logo-mascot.svg';
+import '../assets/styles/site.scss';
+
+class BaseLayout extends React.Component {
+  state = {
+    isMobileNavOpen: false,
+  };
+
+  componentDidMount() {
+    this.viewportMediumMin = window.matchMedia(`(min-width: ${styles.viewport.medium})`);
+    this.viewportMediumMin.addListener(this.checkSize);
+
+    window.onpopstate = (event) => {
+      if (event.srcElement.location.pathname === event.target.location.pathname) return;
+
+      this.setState({
+        isMobileNavOpen: false,
+      }, () => {
+        this.clearMobileNavClasses();
+      });
+    };
+  }
+
+  componentWillUnmount() {
+    this.viewportMediumMin.removeListener(this.checkSize);
+  }
+
+  // Make sure we close mobile nav if resizing from mobile to desktop
+  checkSize = (event) => {
+    const { isMobileNavOpen } = this.state;
+
+    if (isMobileNavOpen && event.matches) {
+      this.handleMobileNavToggle();
+    }
+  }
+
+  handleMobileNavToggle = () => {
+    const { isMobileNavOpen } = this.state;
+
+    this.setState({
+      isMobileNavOpen: !isMobileNavOpen,
+    });
+  }
+
+  render() {
+    const { children, pageTitle } = this.props;
+    const { isMobileNavOpen } = this.state;
+
+    const navClasses = cx('docs__sidebar', {
+      [config.classes.open]: isMobileNavOpen,
+    });
+
+    return (
+      <Foundation>
+        <div className="container">
+          <div className="docs__wrapper">
+            <aside className={navClasses}>
+              <div className="docs__sidebar-topWrapper">
+                <Link to="/" className="docs__mascot">
+                  <img src={mascot} alt="ChaosKit" />
+                </Link>
+                <Button
+                  type="reset"
+                  onClick={this.handleMobileNavToggle}
+                  className="docs__sidebar-mobileToggle u-hiddenUp@medium"
+                />
+              </div>
+              <div className="docs__sidebar-listWrapper">
+                <h5>Concepts</h5>
+                <List>
+                  <ListItem>
+                    <Link to="/sass/" activeClassName={config.classes.active}>Sass</Link>
+                  </ListItem>
+                </List>
+                <h5>Components</h5>
+                <List>
+                  <ListItem>
+                    <Link to="/alert/" activeClassName={config.classes.active}>Alert</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/avatar/" activeClassName={config.classes.active}>Avatar</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/badge/" activeClassName={config.classes.active}>Badge</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/block-grid/" activeClassName={config.classes.active}>Block Grid</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/button/" activeClassName={config.classes.active}>Button</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/close/" activeClassName={config.classes.active}>Close</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/grid/" activeClassName={config.classes.active}>Grid</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/icon/" activeClassName={config.classes.active}>Icon</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/inline/" activeClassName={config.classes.active}>Inline</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/list/" activeClassName={config.classes.active}>List</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/loader/" activeClassName={config.classes.active}>Loader</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/modal/" activeClassName={config.classes.active}>Modal</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/reveal/" activeClassName={config.classes.active}>Reveal</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/tooltip/" activeClassName={config.classes.active}>Tooltip</Link>
+                  </ListItem>
+                </List>
+                <h5>Forms</h5>
+                <List>
+                  <ListItem>
+                    <Link to="/checkbox/" activeClassName={config.classes.active}>Checkbox</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/choices-single/" activeClassName={config.classes.active}>Choices Single</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/choices-multi/" activeClassName={config.classes.active}>Choices Multi</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/input/" activeClassName={config.classes.active}>Input</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/radio/" activeClassName={config.classes.active}>Radio</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/select/" activeClassName={config.classes.active}>Select</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/textarea/" activeClassName={config.classes.active}>Textarea</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/toggle/" activeClassName={config.classes.active}>Toggle</Link>
+                  </ListItem>
+                </List>
+                <h5>Utilities</h5>
+                <List>
+                  <ListItem>
+                    <Link to="/flex/" activeClassName={config.classes.active}>Flex</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/typography/" activeClassName={config.classes.active}>Typography</Link>
+                  </ListItem>
+                  <ListItem>
+                    <Link to="/whitespace/" activeClassName={config.classes.active}>Whitespace</Link>
+                  </ListItem>
+                </List>
+              </div>
+            </aside>
+            <main className="docs__content">
+              {pageTitle && <h1>{pageTitle}</h1>}
+              {children}
+            </main>
+          </div>
+        </div>
+        <footer className="u-bgPanel u-mt--large u-pv--regular">
+          <div className="container">
+            <Inline>
+              <div className="u-textMuted u-textSmall">
+                Current Version: <strong className="u-textDefault">{version}</strong>
+              </div>
+              <a className="u-inlineBlock" target="_blank" rel="noopener noreferrer" title="View ChaosKit on GitHub" href="https://www.github.com/gremlin/chaoskit">
+                <Icon icon="github" />
+              </a>
+              <div className="u-textSmall">
+                Ipsum provided by <a target="_blank" rel="noopener noreferrer" href="http://fillerama.io/">Fillerama</a>
+              </div>
+            </Inline>
+          </div>
+        </footer>
+      </Foundation>
+    );
+  }
+}
+
+BaseLayout.propTypes = {
+  children: PropTypes.node,
+  pageTitle: PropTypes.string,
+};
+
+export default BaseLayout;

--- a/src/layouts/Foundation.js
+++ b/src/layouts/Foundation.js
@@ -1,16 +1,10 @@
 import React, { Fragment } from 'react';
-import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { StaticQuery, graphql, Link } from 'gatsby';
+import { StaticQuery, graphql } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import 'what-input';
 
 import { styles } from '../helpers/styles';
-import { config } from '../helpers/config';
-import { Button, Icon, Inline, List, ListItem } from '../components';
-import { version } from '../../package.json';
-
-import mascot from '../assets/media/logo-mascot.svg';
 import GiraLight from '../assets/fonts/gira-sans-light.woff';
 import GiraMedium from '../assets/fonts/gira-sans-regular.woff';
 import GiraBold from '../assets/fonts/gira-sans-bold.woff';
@@ -19,51 +13,9 @@ import CircularMedium from '../assets/fonts/lineto-circular-medium.woff';
 import CircularBlack from '../assets/fonts/lineto-circular-black.woff';
 import '../assets/styles/site.scss';
 
-class Foundation extends React.Component {
-  state = {
-    isMobileNavOpen: false,
-  };
-
-  componentDidMount() {
-    this.viewportMediumMin = window.matchMedia(`(min-width: ${styles.viewport.medium})`);
-    this.viewportMediumMin.addListener(this.checkSize);
-
-    window.onpopstate = (event) => {
-      if (event.srcElement.location.pathname === event.target.location.pathname) return;
-
-      this.setState({
-        isMobileNavOpen: false,
-      }, () => {
-        this.clearMobileNavClasses();
-      });
-    };
-  }
-
-  componentWillUnmount() {
-    this.viewportMediumMin.removeListener(this.checkSize);
-  }
-
-  // Make sure we close mobile nav if resizing from mobile to desktop
-  checkSize = (event) => {
-    const { isMobileNavOpen } = this.state;
-
-    if (isMobileNavOpen && event.matches) {
-      this.handleMobileNavToggle();
-    }
-  }
-
-  handleMobileNavToggle = () => {
-    const { isMobileNavOpen } = this.state;
-
-    this.setState({
-      isMobileNavOpen: !isMobileNavOpen,
-    });
-  }
-
-  render() {
-    return (
-      <StaticQuery
-        query={graphql`
+const Foundation = props => (
+  <StaticQuery
+    query={graphql`
         query FoundationPageData {
           site {
             siteMetadata {
@@ -73,31 +25,26 @@ class Foundation extends React.Component {
           }
         }
       `}
-        render={(data) => {
-          const {
-            site: {
-              siteMetadata: {
-                title, description,
-              },
-            },
-          } = data;
-          const { children, pageTitle } = this.props;
-          const { isMobileNavOpen } = this.state;
+    render={(data) => {
+      const {
+        site: {
+          siteMetadata: {
+            title, description,
+          },
+        },
+      } = data;
+      const { children } = props;
 
-          const navClasses = cx('docs__sidebar', {
-            [config.classes.open]: isMobileNavOpen,
-          });
-
-          return (
-            <Fragment>
-              <Helmet
-                title={title}
-                meta={[
-                  { name: 'description', content: description },
-                ]}
-              >
-                {/* Adding in webfonts here to get around strange Gatsby issue https://github.com/gatsbyjs/gatsby/issues/9826 */}
-                <style type="text/css">{`
+      return (
+        <Fragment>
+          <Helmet
+            title={title}
+            meta={[
+              { name: 'description', content: description },
+            ]}
+          >
+            {/* Adding in webfonts here to get around strange Gatsby issue https://github.com/gatsbyjs/gatsby/issues/9826 */}
+            <style type="text/css">{`
                 @font-face {
                   font-family: Gira;
                   src: local(😜), url(${GiraLight}) format('woff');
@@ -140,146 +87,17 @@ class Foundation extends React.Component {
                   font-style: normal;
                 }
               `}
-                </style>
-              </Helmet>
-              <div className="container">
-                <div className="docs__wrapper">
-                  <aside className={navClasses}>
-                    <div className="docs__sidebar-topWrapper">
-                      <Link to="/" className="docs__mascot">
-                        <img src={mascot} alt="ChaosKit" />
-                      </Link>
-                      <Button
-                        type="reset"
-                        onClick={this.handleMobileNavToggle}
-                        className="docs__sidebar-mobileToggle u-hiddenUp@medium"
-                      />
-                    </div>
-                    <div className="docs__sidebar-listWrapper">
-                      <h5>Concepts</h5>
-                      <List>
-                        <ListItem>
-                          <Link to="/sass/" activeClassName={config.classes.active}>Sass</Link>
-                        </ListItem>
-                      </List>
-                      <h5>Components</h5>
-                      <List>
-                        <ListItem>
-                          <Link to="/alert/" activeClassName={config.classes.active}>Alert</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/avatar/" activeClassName={config.classes.active}>Avatar</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/badge/" activeClassName={config.classes.active}>Badge</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/block-grid/" activeClassName={config.classes.active}>Block Grid</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/button/" activeClassName={config.classes.active}>Button</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/close/" activeClassName={config.classes.active}>Close</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/grid/" activeClassName={config.classes.active}>Grid</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/icon/" activeClassName={config.classes.active}>Icon</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/inline/" activeClassName={config.classes.active}>Inline</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/list/" activeClassName={config.classes.active}>List</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/loader/" activeClassName={config.classes.active}>Loader</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/modal/" activeClassName={config.classes.active}>Modal</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/reveal/" activeClassName={config.classes.active}>Reveal</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/tooltip/" activeClassName={config.classes.active}>Tooltip</Link>
-                        </ListItem>
-                      </List>
-                      <h5>Forms</h5>
-                      <List>
-                        <ListItem>
-                          <Link to="/checkbox/" activeClassName={config.classes.active}>Checkbox</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/choices-single/" activeClassName={config.classes.active}>Choices Single</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/choices-multi/" activeClassName={config.classes.active}>Choices Multi</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/input/" activeClassName={config.classes.active}>Input</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/radio/" activeClassName={config.classes.active}>Radio</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/select/" activeClassName={config.classes.active}>Select</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/textarea/" activeClassName={config.classes.active}>Textarea</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/toggle/" activeClassName={config.classes.active}>Toggle</Link>
-                        </ListItem>
-                      </List>
-                      <h5>Utilities</h5>
-                      <List>
-                        <ListItem>
-                          <Link to="/flex/" activeClassName={config.classes.active}>Flex</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/typography/" activeClassName={config.classes.active}>Typography</Link>
-                        </ListItem>
-                        <ListItem>
-                          <Link to="/whitespace/" activeClassName={config.classes.active}>Whitespace</Link>
-                        </ListItem>
-                      </List>
-                    </div>
-                  </aside>
-                  <main className="docs__content">
-                    {pageTitle && <h1>{pageTitle}</h1>}
-                    {children}
-                  </main>
-                </div>
-              </div>
-              <footer className="u-bgPanel u-mt--large u-pv--regular">
-                <div className="container">
-                  <Inline>
-                    <div className="u-textMuted u-textSmall">
-                      Current Version: <strong className="u-textDefault">{version}</strong>
-                    </div>
-                    <a className="u-inlineBlock" target="_blank" rel="noopener noreferrer" title="View ChaosKit on GitHub" href="https://www.github.com/gremlin/chaoskit">
-                      <Icon icon="github" />
-                    </a>
-                    <div className="u-textSmall">
-                      Ipsum provided by <a target="_blank" rel="noopener noreferrer" href="http://fillerama.io/">Fillerama</a>
-                    </div>
-                  </Inline>
-                </div>
-              </footer>
-            </Fragment>
-          );
-        }}
-      />
-    );
-  }
-}
+            </style>
+          </Helmet>
+          {children}
+        </Fragment>
+      );
+    }}
+  />
+);
 
 Foundation.propTypes = {
   children: PropTypes.node,
-  pageTitle: PropTypes.string,
 };
 
 export default Foundation;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import Foundation from '../layouts/Foundation';
+import { Button, Icon } from '../components';
+
+const NotFound = () => (
+  <Foundation>
+    <div className="notFound__wrapper u-pv--large u-textCenter u-contrast">
+      <div className="container">
+        <h1 className="notFound__title">404</h1>
+        <Button type="default" url="/">
+          <Icon icon="arrow-left" className="u-mr--small" />
+          Back Home
+        </Button>
+      </div>
+    </div>
+  </Foundation>
+);
+
+export default NotFound;

--- a/src/pages/alert.js
+++ b/src/pages/alert.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert, Button } from '../components';
 import Live from '../docs/Live';
 
@@ -43,7 +43,7 @@ const AlertScope = {
 };
 
 const AlertDocs = () => (
-  <FoundationLayout pageTitle="Alert">
+  <BaseLayout pageTitle="Alert">
     <p>Alerts can be used to draw attention to and provide context to key page actions.</p>
 
     <Live
@@ -52,7 +52,7 @@ const AlertDocs = () => (
       component={Alert}
       propDescriptions={AlertPropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default AlertDocs;

--- a/src/pages/avatar.js
+++ b/src/pages/avatar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert, Avatar, Inline } from '../components';
 import Live from '../docs/Live';
 
@@ -29,7 +29,7 @@ const AvatarScope = {
 };
 
 const AvatarDocs = () => (
-  <FoundationLayout pageTitle="Avatar">
+  <BaseLayout pageTitle="Avatar">
     <p>Avatars provide flexible ways of adding personality to our applications.</p>
 
     <Alert type="warning" title="Note">
@@ -51,7 +51,7 @@ const AvatarDocs = () => (
       component={Avatar}
       showDocs={false}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default AvatarDocs;

--- a/src/pages/badge.js
+++ b/src/pages/badge.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Badge, Inline } from '../components';
 import Live from '../docs/Live';
 
@@ -30,7 +30,7 @@ const BadgeScope = {
 };
 
 const BadgeDocs = () => (
-  <FoundationLayout pageTitle="Badge">
+  <BaseLayout pageTitle="Badge">
     <p>Badges are indicators and have no interactivity. They are used to indicate an item&apos;s current state.</p>
 
     <Live
@@ -48,7 +48,7 @@ const BadgeDocs = () => (
       component={Badge}
       showDocs={false}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default BadgeDocs;

--- a/src/pages/block-grid.js
+++ b/src/pages/block-grid.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert } from '../components';
 import Live from '../docs/Live';
 
@@ -78,7 +78,7 @@ const BlockGridAlignmentExample = `
 const BlockGridScope = {};
 
 const BlockGridDocs = () => (
-  <FoundationLayout pageTitle="BlockGrid">
+  <BaseLayout pageTitle="BlockGrid">
     <p>Block Grids allow us to evenly split list items within a grid by specifying the number of items per row. Block Grids inherently add a negative left and right offset so it is flush with the edge of the column it is in.</p>
 
     <Alert type="warning" title="Note‍" className="u-mb--regular">
@@ -162,7 +162,7 @@ const BlockGridDocs = () => (
       scope={BlockGridScope}
       showDocs={false}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default BlockGridDocs;

--- a/src/pages/button.js
+++ b/src/pages/button.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert, Button, Icon, Inline, List, ListItem } from '../components';
 import Live from '../docs/Live';
 
@@ -73,7 +73,7 @@ const ButtonDocs = () => {
   };
 
   return (
-    <FoundationLayout pageTitle="Button">
+    <BaseLayout pageTitle="Button">
       <Live
         code={ButtonExample}
         scope={ButtonScope}
@@ -129,7 +129,7 @@ const ButtonDocs = () => {
         <p>If you&apos;d like to override the contrast styles for a given button, you can apply the <code>noContrast</code> prop.</p>
       </Alert>
 
-    </FoundationLayout>
+    </BaseLayout>
   );
 };
 

--- a/src/pages/checkbox.js
+++ b/src/pages/checkbox.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { CheckboxGroup, Checkbox } from '../components';
 
@@ -29,14 +29,14 @@ const CheckboxScope = {
 const CheckboxPropDescriptions = {};
 
 const CheckboxDocs = () => (
-  <FoundationLayout pageTitle="Checkbox">
+  <BaseLayout pageTitle="Checkbox">
     <Live
       code={CheckboxExample}
       scope={CheckboxScope}
       component={Checkbox}
       propDescriptions={CheckboxPropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default CheckboxDocs;

--- a/src/pages/choices-multi.js
+++ b/src/pages/choices-multi.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { ChoicesMulti } from '../components';
 
@@ -70,7 +70,7 @@ const ChoicesMultiScope = {
 const ChoicesMultiPropDescriptions = {};
 
 const ChoicesMultiDocs = () => (
-  <FoundationLayout pageTitle="Choices Multi">
+  <BaseLayout pageTitle="Choices Multi">
     <p>Uses <a href="https://github.com/paypal/downshift">downshift</a> to provide ULTIMATE-POWER and flexibility to more complex <code>&lt;select&gt;</code> UIs.</p>
     <Live
       code={ChoicesMultiExample}
@@ -78,7 +78,7 @@ const ChoicesMultiDocs = () => (
       component={ChoicesMulti}
       propDescriptions={ChoicesMultiPropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default ChoicesMultiDocs;

--- a/src/pages/choices-single.js
+++ b/src/pages/choices-single.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { ChoicesSingle } from '../components';
 
@@ -51,7 +51,7 @@ const ChoicesSingleScope = {
 const ChoicesSinglePropDescriptions = {};
 
 const ChoicesSingleDocs = () => (
-  <FoundationLayout pageTitle="Choices Single">
+  <BaseLayout pageTitle="Choices Single">
     <p>Uses <a href="https://github.com/paypal/downshift">downshift</a> to provide ULTIMATE-POWER and flexibility to more complex <code>&lt;select&gt;</code> UIs.</p>
     <Live
       code={ChoicesSingleExample}
@@ -59,7 +59,7 @@ const ChoicesSingleDocs = () => (
       component={ChoicesSingle}
       propDescriptions={ChoicesSinglePropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default ChoicesSingleDocs;

--- a/src/pages/close.js
+++ b/src/pages/close.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Close } from '../components';
 import Live from '../docs/Live';
 
@@ -23,7 +23,7 @@ const CloseScope = {
 };
 
 const CloseDocs = () => (
-  <FoundationLayout pageTitle="Close">
+  <BaseLayout pageTitle="Close">
     <p>Plain and simple - a reusable and ready-to-interact-with close button.</p>
 
     <Live
@@ -32,7 +32,7 @@ const CloseDocs = () => (
       component={Close}
       propDescriptions={ClosePropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default CloseDocs;

--- a/src/pages/flex.js
+++ b/src/pages/flex.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert } from '../components';
 import Live from '../docs/Live';
 
@@ -35,7 +35,7 @@ const FlexDocs = () => {
 `.trim();
 
   return (
-    <FoundationLayout pageTitle="Flex">
+    <BaseLayout pageTitle="Flex">
       <p>We take advantage of Flexbox for many of our components; so it made sense for us to expose a number of utilities as well.</p>
 
       <h3>Deep match</h3>
@@ -142,7 +142,7 @@ const FlexDocs = () => {
           </tr>
         </tbody>
       </table>
-    </FoundationLayout>
+    </BaseLayout>
   );
 };
 

--- a/src/pages/grid.js
+++ b/src/pages/grid.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert } from '../components';
 import Live from '../docs/Live';
 
@@ -124,7 +124,7 @@ const GridSourceOrderExample = `
 const GridScope = {};
 
 const GridDocs = () => (
-  <FoundationLayout pageTitle="Grid">
+  <BaseLayout pageTitle="Grid">
     <p>We use a 12-column grid with a default grid-gutter of <code>16px</code>. Columns that add-up to more than 12 automatically get some space in-between. So you can use grids for dayz &apos;yo.</p>
 
     <Alert type="warning" title="Note‍" className="u-mb--regular">
@@ -247,7 +247,7 @@ const GridDocs = () => (
       scope={GridScope}
       showDocs={false}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default GridDocs;

--- a/src/pages/icon.js
+++ b/src/pages/icon.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Icon, Inline } from '../components';
 import Live from '../docs/Live';
 import icons from '../assets/icons/icons.json';
@@ -46,7 +46,7 @@ const IconPropDescriptions = {
 };
 
 const IconDocs = () => (
-  <FoundationLayout pageTitle="Icon">
+  <BaseLayout pageTitle="Icon">
     <p>All UI-orientated icons follow the same <code>viewBox</code>, <code>width/height</code>, and <code>stroke</code> attributes for ease and re-usability. Icons are located within the <code>src/assets/icons/</code> directory and are optimized, mangled, and sent along via a JSON file that allows us to import and validate references more easily and only bundle what we actually use in our applications.</p>
     <Live
       code={IconExample}
@@ -72,7 +72,7 @@ const IconDocs = () => (
       component={Icon}
       showDocs={false}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default IconDocs;

--- a/src/pages/inline.js
+++ b/src/pages/inline.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert, Button, Inline } from '../components';
 import Live from '../docs/Live';
 
@@ -26,7 +26,7 @@ const InlineScope = {
 };
 
 const InlineDocs = () => (
-  <FoundationLayout pageTitle="Inline">
+  <BaseLayout pageTitle="Inline">
     <p>Sometimes your content doesn&apos;t belong in a grid system. So, for when you have more &quot;free-form&quot; content that you&apos;d like proper spacing horizontally and vertically when they stack, we created the Inline component. You can modify alignment by using our <a href="/flex/">Flex</a> utilities.</p>
 
     <Live
@@ -39,7 +39,7 @@ const InlineDocs = () => (
     <Alert type="warning" title="Note‍">
       <p>There should be no whitespace modifiers attached to the Inline component or its direct children. You can attach them on adjacent DOM or by wrapping the component in a <code>&lt;div&gt;</code></p>
     </Alert>
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default InlineDocs;

--- a/src/pages/input.js
+++ b/src/pages/input.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { Input } from '../components';
 
@@ -73,7 +73,7 @@ const InputPropDescriptions = {
 };
 
 const InputDocs = () => (
-  <FoundationLayout pageTitle="Input">
+  <BaseLayout pageTitle="Input">
     <p>Uses <a target="_blank" rel="noopener noreferrer" href="https://github.com/text-mask/text-mask/">text-mask</a> to provide masking capabilities for better UX.</p>
 
     <Live
@@ -82,7 +82,7 @@ const InputDocs = () => (
       component={Input}
       propDescriptions={InputPropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default InputDocs;

--- a/src/pages/list.js
+++ b/src/pages/list.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { List, ListItem } from '../components';
 
@@ -44,14 +44,14 @@ const ListPropDescriptions = {
 };
 
 const ListDocs = () => (
-  <FoundationLayout pageTitle="List">
+  <BaseLayout pageTitle="List">
     <Live
       code={ListExample}
       scope={ListScope}
       component={List}
       propDescriptions={ListPropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default ListDocs;

--- a/src/pages/loader.js
+++ b/src/pages/loader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert, Loader, Inline } from '../components';
 import Live from '../docs/Live';
 
@@ -21,7 +21,7 @@ const LoaderScope = {
 };
 
 const LoaderDocs = () => (
-  <FoundationLayout pageTitle="Loader">
+  <BaseLayout pageTitle="Loader">
     <p>While no one likes to wait; great things come to those that do. For those times, a loader is available to notify users some magic is happening behind the scenes.</p>
 
     <Live
@@ -43,7 +43,7 @@ const LoaderDocs = () => (
     <Alert type="warning" title="🕵️ Did you know?‍">
       <p>The Loader component is re-used within the <a href="/button/">Button</a> component via its <code>loading</code> prop.</p>
     </Alert>
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default LoaderDocs;

--- a/src/pages/modal.js
+++ b/src/pages/modal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { Alert, Modal, ModalHeader, ModalFooter, ModalBody, Button } from '../components';
 
@@ -51,7 +51,7 @@ const ModalPropDescriptions = {
 };
 
 const ModalDocs = () => (
-  <FoundationLayout pageTitle="Modal">
+  <BaseLayout pageTitle="Modal">
     <Live
       code={ModalExample}
       scope={ModalScope}
@@ -61,7 +61,7 @@ const ModalDocs = () => (
     <Alert type="warning" title="Note">
       <p>When resetting UI on-close (like form-values), use the <code>onReverseComplete</code> prop; which waits until the animation is complete to fire</p>
     </Alert>
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default ModalDocs;

--- a/src/pages/radio.js
+++ b/src/pages/radio.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { RadioGroup, Radio } from '../components';
 
@@ -30,14 +30,14 @@ const RadioScope = {
 const RadioPropDescriptions = {};
 
 const RadioDocs = () => (
-  <FoundationLayout pageTitle="Radio">
+  <BaseLayout pageTitle="Radio">
     <Live
       code={RadioExample}
       scope={RadioScope}
       component={Radio}
       propDescriptions={RadioPropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default RadioDocs;

--- a/src/pages/reveal.js
+++ b/src/pages/reveal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { Reveal } from '../components';
 
@@ -36,14 +36,14 @@ const RevealPropDescriptions = {
 };
 
 const RevealDocs = () => (
-  <FoundationLayout pageTitle="Reveal">
+  <BaseLayout pageTitle="Reveal">
     <Live
       code={RevealExample}
       scope={RevealScope}
       component={Reveal}
       propDescriptions={RevealPropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default RevealDocs;

--- a/src/pages/sass.mdx
+++ b/src/pages/sass.mdx
@@ -133,6 +133,20 @@ Hooks allow us to inject additional styles alongside components to reduce select
 }
 ```
 
+#### Extending
+
+In a perfect-world, controlling DOM and utilizing utility classes is the bees-knees. In real-world applications; that's easier said than done. Thankfully, Sass has built-in support for extending portions of your codebase with their `@extend` directive. Extending classes however, can be a crap-shoot; as it duplicates every instance of that selector. That's why we've implemented `%placeholders` for some of our components; namely our utilities. You can use them like so:
+
+```scss
+.module-title {
+  @extend %u-textFluid--h3-h4;
+}
+```
+
+> Note
+>
+> Once Sass supports [dynamic mixin names](https://github.com/sass/sass/issues/626) we'll most likely move things over to them; since they can perform minutely better during GZIP compression.
+
 #### Removing components
 
 While we may be partial, you might not need all the magic our framework provides. In the interest of size, we provide a configurable `$components` array that you can interact with in two ways:

--- a/src/pages/select.js
+++ b/src/pages/select.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { Select } from '../components';
 
@@ -48,14 +48,14 @@ const SelectPropDescriptions = {
 };
 
 const SelectDocs = () => (
-  <FoundationLayout pageTitle="Select">
+  <BaseLayout pageTitle="Select">
     <Live
       code={SelectExample}
       scope={SelectScope}
       component={Select}
       propDescriptions={SelectPropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default SelectDocs;

--- a/src/pages/textarea.js
+++ b/src/pages/textarea.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { Textarea } from '../components';
 
@@ -34,7 +34,7 @@ const TextareaPropDescriptions = {
 };
 
 const TextareaDocs = () => (
-  <FoundationLayout pageTitle="Textarea">
+  <BaseLayout pageTitle="Textarea">
     <p>Uses <a href="https://github.com/andreypopp/react-textarea-autosize">react-textarea-autosize</a> to control growth automatically.</p>
     <Live
       code={TextareaExample}
@@ -42,7 +42,7 @@ const TextareaDocs = () => (
       component={Textarea}
       propDescriptions={TextareaPropDescriptions}
     />
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default TextareaDocs;

--- a/src/pages/toggle.js
+++ b/src/pages/toggle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { Alert, Toggle } from '../components';
 
@@ -42,7 +42,7 @@ const ToggleScope = {
 const TogglePropDescriptions = {};
 
 const ToggleDocs = () => (
-  <FoundationLayout pageTitle="Toggle">
+  <BaseLayout pageTitle="Toggle">
     <Live
       code={ToggleExample}
       scope={ToggleScope}
@@ -52,7 +52,7 @@ const ToggleDocs = () => (
     <Alert type="warning" title="Note">
       <p>Toggles automatically inherit contrast styles when placed within a wrapper that contains the global <code>.u-contrast</code> class.</p>
     </Alert>
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default ToggleDocs;

--- a/src/pages/tooltip.js
+++ b/src/pages/tooltip.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import Live from '../docs/Live';
 import { Alert, Button, Tooltip, Icon, Inline, List, ListItem } from '../components';
 
@@ -42,7 +42,7 @@ const TooltipPropDescriptions = {
 };
 
 const TooltipDocs = () => (
-  <FoundationLayout pageTitle="Tooltip">
+  <BaseLayout pageTitle="Tooltip">
     <Live
       code={TooltipExample}
       scope={TooltipScope}
@@ -55,7 +55,7 @@ const TooltipDocs = () => (
         <ListItem>Tooltip content can contain normal strings or other components. Go crazy!</ListItem>
       </List>
     </Alert>
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default TooltipDocs;

--- a/src/pages/typography.js
+++ b/src/pages/typography.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert } from '../components';
 
 const TypographyDocs = () => (
-  <FoundationLayout pageTitle="Typography">
+  <BaseLayout pageTitle="Typography">
     <p>We provide a variety of utility classes that can be used on their own; chained together with components, and/or chained together with other utility classes to create various UI needs. Apply classes to the parent to avoid repeating the utility unnecessarily whenever possible.</p>
 
     <Alert type="warning" title="Note">
@@ -220,7 +220,7 @@ const TypographyDocs = () => (
       </tbody>
     </table>
 
-  </FoundationLayout>
+  </BaseLayout>
 );
 
 export default TypographyDocs;

--- a/src/pages/whitespace.js
+++ b/src/pages/whitespace.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import FoundationLayout from '../layouts/Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 import { Alert, Inline } from '../components';
 import Live from '../docs/Live';
 
@@ -13,7 +13,7 @@ const WhitespaceDocs = () => {
 `.trim();
 
   return (
-    <FoundationLayout pageTitle="Whitespce">
+    <BaseLayout pageTitle="Whitespce">
       <p>We often need to apply margins or padding to individual elements. These utilities should be exclusively used for this type of spacing.</p>
       <p>To add space to any element we add a class of <code>.u-{'{type}'}{'{direction}'}--{'{amount}'}</code>. For example, if we wanted to add 32px of margin below an element, we would add a class of <code>.u-mb--large</code>.</p>
 
@@ -62,7 +62,7 @@ const WhitespaceDocs = () => {
         code={WhitespaceExample}
         scope={{}}
       />
-    </FoundationLayout>
+    </BaseLayout>
   );
 };
 

--- a/src/templates/Article.js
+++ b/src/templates/Article.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import FoundationLayout from './Foundation';
+import BaseLayout from '../layouts/BaseLayout';
 
 const Article = (props) => {
   const { children } = props;
 
   return (
-    <FoundationLayout>
+    <BaseLayout>
       {children}
-    </FoundationLayout>
+    </BaseLayout>
   );
 };
 


### PR DESCRIPTION
While working on a new portion of the marketing site, I had the need to extend some of the base styles from the framework to interact with DOM that I didn't control (yuh, sucks). However, the current implementation had me extending classes; which introduced some pretty decent bloat in the final output.

Something that I should have been doing previously, but I've made most of the utility classes (and some components I know I need -- to start with proving the concept) to make `%placeholders` readily available for each classname. [This article](https://webinista.com/updates/dont-use-extend-sass/) goes into a bit more detail on why this is better than extending classes. 

Placeholders won't add any weight to the framework since they're silent, but provides the flexibility when needed.

There's also an addition in there for a shorter way of referencing utility classes per breakpoint (you'll see that in `_flex.scss`). I've also used this opportunity to start getting rid of the nested style; as it's a PITA to search through later and just makes selectors more complicated than they need to be (example in `_badge.scss`).