### PR TITLE
useLockBody scroll for locking scrolling

### DIFF
--- a/src/assets/styles/_modal.scss
+++ b/src/assets/styles/_modal.scss
@@ -19,12 +19,6 @@ $modal-large-enable: true !default;
 //
 
 @mixin modal() {
-  // Body styles to prevent scrolling
-  .has-openModal {
-    height: 100%;
-    overflow: hidden;
-  }
-
   // 1. JS styles
   .modal {
     position: fixed;

--- a/src/assets/styles/_offCanvas.scss
+++ b/src/assets/styles/_offCanvas.scss
@@ -18,12 +18,6 @@ $offCanvas-panel-width: 300px !default;
 //
 
 @mixin offCanvas() {
-  // Body styles to prevent scrolling
-  .has-openOffCanvas {
-    height: 100%;
-    overflow: hidden;
-  }
-
   // 1. JS styles
   .offCanvas {
     position: fixed;

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,7 +1,10 @@
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useRef, useState, useEffect } from 'react';
+import React, {
+  Fragment, useRef, useState, useEffect,
+} from 'react';
 import useUpdateEffect from 'react-use/lib/useUpdateEffect';
+import useLockBodyScroll from 'react-use/lib/useLockBodyScroll';
 import ReactDOM from 'react-dom';
 import { TimelineMax } from 'gsap/TweenMax';
 
@@ -152,21 +155,24 @@ const Modal = ({
   );
 
   return (
-    renderModal
-    && ReactDOM.createPortal(
-      <div /* eslint-disable-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-        className={modalClasses}
-        onClick={handleOutsideModalClick}
-        ref={modalRef}
-        data-modalroot
-        {...opts}
-      >
-        <div className="modal-dialog" ref={modalDialogRef}>
-          {children}
-        </div>
-      </div>,
-      document.body,
-    )
+    <Fragment>
+      {useLockBodyScroll(renderModal)}
+      {renderModal
+        && ReactDOM.createPortal(
+          <div /* eslint-disable-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+            className={modalClasses}
+            onClick={handleOutsideModalClick}
+            ref={modalRef}
+            data-modalroot
+            {...opts}
+          >
+            <div className="modal-dialog" ref={modalDialogRef}>
+              {children}
+            </div>
+          </div>,
+          document.body,
+        )}
+    </Fragment>
   );
 };
 

--- a/src/components/OffCanvas.js
+++ b/src/components/OffCanvas.js
@@ -1,7 +1,10 @@
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useRef, useState, useEffect } from 'react';
+import React, {
+  Fragment, useRef, useState, useEffect,
+} from 'react';
 import useUpdateEffect from 'react-use/lib/useUpdateEffect';
+import useLockBodyScroll from 'react-use/lib/useLockBodyScroll';
 import ReactDOM from 'react-dom';
 import { TimelineMax } from 'gsap/TweenMax';
 
@@ -165,22 +168,28 @@ const OffCanvas = ({
   );
 
   return (
-    renderOffCanvas
-    && ReactDOM.createPortal(
-      <div /* eslint-disable-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-        className={classes}
-        onClick={handleOutsideOffCanvasClick}
-        ref={offCanvasRef}
-        data-offcanvasroot
-        {...opts}
-      >
-        <div className="offCanvas-panel" ref={offCanvasPanelRef}>
-          <Close onClick={handleOffCanvasToggle} className="offCanvas-close" />
-          {children}
-        </div>
-      </div>,
-      document.body,
-    )
+    <Fragment>
+      {useLockBodyScroll(renderOffCanvas)}
+      {renderOffCanvas
+        && ReactDOM.createPortal(
+          <div /* eslint-disable-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+            className={classes}
+            onClick={handleOutsideOffCanvasClick}
+            ref={offCanvasRef}
+            data-offcanvasroot
+            {...opts}
+          >
+            <div className="offCanvas-panel" ref={offCanvasPanelRef}>
+              <Close
+                onClick={handleOffCanvasToggle}
+                className="offCanvas-close"
+              />
+              {children}
+            </div>
+          </div>,
+          document.body,
+        )}
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
Uses `useLockBodyScroll` from [`react-use`](https://github.com/streamich/react-use) to provide a more consistent interface for locking scroll on the body element for `<Modal />` and `<OffCanvas />`